### PR TITLE
Add modpack install, game launch, and settings

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
             "license": "MIT",
             "dependencies": {
                 "@tauri-apps/api": "^2",
+                "@tauri-apps/plugin-dialog": "^2.6.0",
                 "@tauri-apps/plugin-opener": "^2",
                 "react": "^19.2.4",
                 "react-dom": "^19.2.4"
@@ -1639,6 +1640,15 @@
             ],
             "engines": {
                 "node": ">= 10"
+            }
+        },
+        "node_modules/@tauri-apps/plugin-dialog": {
+            "version": "2.6.0",
+            "resolved": "https://registry.npmjs.org/@tauri-apps/plugin-dialog/-/plugin-dialog-2.6.0.tgz",
+            "integrity": "sha512-q4Uq3eY87TdcYzXACiYSPhmpBA76shgmQswGkSVio4C82Sz2W4iehe9TnKYwbq7weHiL88Yw19XZm7v28+Micg==",
+            "license": "MIT OR Apache-2.0",
+            "dependencies": {
+                "@tauri-apps/api": "^2.8.0"
             }
         },
         "node_modules/@tauri-apps/plugin-opener": {

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "license": "MIT",
     "dependencies": {
         "@tauri-apps/api": "^2",
+        "@tauri-apps/plugin-dialog": "^2.6.0",
         "@tauri-apps/plugin-opener": "^2",
         "react": "^19.2.4",
         "react-dom": "^19.2.4"

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -2220,6 +2220,7 @@ dependencies = [
  "tar",
  "tauri",
  "tauri-build",
+ "tauri-plugin-dialog",
  "tauri-plugin-opener",
  "thiserror 2.0.18",
  "tokio",
@@ -3470,6 +3471,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "rfd"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a15ad77d9e70a92437d8f74c35d99b4e4691128df018833e99f90bcd36152672"
+dependencies = [
+ "block2",
+ "dispatch2",
+ "glib-sys",
+ "gobject-sys",
+ "gtk-sys",
+ "js-sys",
+ "log",
+ "objc2",
+ "objc2-app-kit",
+ "objc2-core-foundation",
+ "objc2-foundation",
+ "raw-window-handle",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+ "windows-sys 0.60.2",
+]
+
+[[package]]
 name = "ring"
 version = "0.17.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4368,6 +4393,46 @@ dependencies = [
  "tauri-utils",
  "toml 0.9.12+spec-1.1.0",
  "walkdir",
+]
+
+[[package]]
+name = "tauri-plugin-dialog"
+version = "2.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9204b425d9be8d12aa60c2a83a289cf7d1caae40f57f336ed1155b3a5c0e359b"
+dependencies = [
+ "log",
+ "raw-window-handle",
+ "rfd",
+ "serde",
+ "serde_json",
+ "tauri",
+ "tauri-plugin",
+ "tauri-plugin-fs",
+ "thiserror 2.0.18",
+ "url",
+]
+
+[[package]]
+name = "tauri-plugin-fs"
+version = "2.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed390cc669f937afeb8b28032ce837bac8ea023d975a2e207375ec05afaf1804"
+dependencies = [
+ "anyhow",
+ "dunce",
+ "glob",
+ "percent-encoding",
+ "schemars 0.8.22",
+ "serde",
+ "serde_json",
+ "serde_repr",
+ "tauri",
+ "tauri-plugin",
+ "tauri-utils",
+ "thiserror 2.0.18",
+ "toml 0.9.12+spec-1.1.0",
+ "url",
 ]
 
 [[package]]

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -1092,6 +1092,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "filetime"
+version = "0.2.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f98844151eee8917efc50bd9e8318cb963ae8b297431495d3f758616ea5c57db"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "libredox",
+]
+
+[[package]]
 name = "find-msvc-tools"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2198,6 +2209,7 @@ version = "0.1.0"
 dependencies = [
  "chrono",
  "directories",
+ "flate2",
  "futures",
  "keyring",
  "reqwest 0.12.28",
@@ -2205,6 +2217,7 @@ dependencies = [
  "serde_json",
  "sha1",
  "sha2",
+ "tar",
  "tauri",
  "tauri-build",
  "tauri-plugin-opener",
@@ -2276,7 +2289,10 @@ version = "0.1.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ddbf48fd451246b1f8c2610bd3b4ac0cc6e149d89832867093ab69a17194f08"
 dependencies = [
+ "bitflags 2.11.0",
  "libc",
+ "plain",
+ "redox_syscall 0.7.3",
 ]
 
 [[package]]
@@ -2784,7 +2800,7 @@ checksum = "2621685985a2ebf1c516881c026032ac7deafcda1a2c9b7850dc81e3dfcb64c1"
 dependencies = [
  "cfg-if",
  "libc",
- "redox_syscall",
+ "redox_syscall 0.5.18",
  "smallvec",
  "windows-link 0.2.1",
 ]
@@ -3026,6 +3042,12 @@ name = "pkg-config"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
+
+[[package]]
+name = "plain"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
 
 [[package]]
 name = "plist"
@@ -3297,6 +3319,15 @@ name = "redox_syscall"
 version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
+dependencies = [
+ "bitflags 2.11.0",
+]
+
+[[package]]
+name = "redox_syscall"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ce70a74e890531977d37e532c34d45e9055d2409ed08ddba14529471ed0be16"
 dependencies = [
  "bitflags 2.11.0",
 ]
@@ -3955,7 +3986,7 @@ dependencies = [
  "objc2-foundation",
  "objc2-quartz-core",
  "raw-window-handle",
- "redox_syscall",
+ "redox_syscall 0.5.18",
  "tracing",
  "wasm-bindgen",
  "web-sys",
@@ -4189,6 +4220,17 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "tar"
+version = "0.4.45"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22692a6476a21fa75fdfc11d452fda482af402c008cdbaf3476414e122040973"
+dependencies = [
+ "filetime",
+ "libc",
+ "xattr",
 ]
 
 [[package]]
@@ -5919,6 +5961,16 @@ dependencies = [
  "libc",
  "once_cell",
  "pkg-config",
+]
+
+[[package]]
+name = "xattr"
+version = "1.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32e45ad4206f6d2479085147f02bc2ef834ac85886624a23575ae137c8aa8156"
+dependencies = [
+ "libc",
+ "rustix",
 ]
 
 [[package]]

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -29,6 +29,8 @@ chrono = { version = "0.4", features = ["serde"] }
 futures = "0.3"
 url = "2"
 keyring = { version = "3", features = ["apple-native", "windows-native", "sync-secret-service"] }
+flate2 = "1"
+tar = "0.4"
 
 [profile.release]
 strip = true

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -31,6 +31,7 @@ url = "2"
 keyring = { version = "3", features = ["apple-native", "windows-native", "sync-secret-service"] }
 flate2 = "1"
 tar = "0.4"
+tauri-plugin-dialog = "2.6.0"
 
 [profile.release]
 strip = true

--- a/src-tauri/src/commands/install.rs
+++ b/src-tauri/src/commands/install.rs
@@ -1,0 +1,16 @@
+use tauri::{AppHandle, State};
+
+use crate::error::LanternError;
+use crate::instance::manager::Instance;
+use crate::minecraft::install;
+use crate::state::AppState;
+
+#[tauri::command]
+pub async fn install_modpack(
+    app: AppHandle,
+    state: State<'_, AppState>,
+    project_id: String,
+    version_id: String,
+) -> Result<Instance, LanternError> {
+    install::install_modpack(app, &state, project_id, version_id).await
+}

--- a/src-tauri/src/commands/launch.rs
+++ b/src-tauri/src/commands/launch.rs
@@ -1,0 +1,51 @@
+use tauri::{AppHandle, State};
+
+use crate::error::LanternError;
+use crate::minecraft::launch;
+use crate::state::AppState;
+
+#[tauri::command]
+pub async fn launch_instance(
+    app: AppHandle,
+    state: State<'_, AppState>,
+    instance_id: String,
+    online: bool,
+    username: Option<String>,
+) -> Result<(), LanternError> {
+    let instance = {
+        let instances = state.instances.lock().unwrap();
+        instances.get(&instance_id)?
+    };
+
+    // Get auth info if online
+    let (auth_name, auth_uuid, auth_token) = if online {
+        let auth = state.auth.lock().unwrap();
+        match (&auth.profile, &auth.tokens) {
+            (Some(profile), Some(tokens)) => (
+                Some(profile.name.clone()),
+                Some(profile.id.clone()),
+                Some(tokens.minecraft_access_token.clone()),
+            ),
+            _ => {
+                return Err(LanternError::Launch(
+                    "Not logged in — sign in or use offline mode".into(),
+                ));
+            }
+        }
+    } else {
+        (username, None, None)
+    };
+
+    launch::launch_instance(app, &state, &instance, online, auth_name, auth_uuid, auth_token)
+        .await?;
+
+    // Update last_played
+    {
+        let instances = state.instances.lock().unwrap();
+        let mut updated = instances.get(&instance_id)?;
+        updated.last_played = Some(chrono::Utc::now());
+        instances.save(&updated)?;
+    }
+
+    Ok(())
+}

--- a/src-tauri/src/commands/mod.rs
+++ b/src-tauri/src/commands/mod.rs
@@ -1,4 +1,6 @@
 pub mod auth;
 pub mod file_locks;
+pub mod install;
 pub mod instances;
+pub mod launch;
 pub mod modpacks;

--- a/src-tauri/src/commands/mod.rs
+++ b/src-tauri/src/commands/mod.rs
@@ -4,3 +4,4 @@ pub mod install;
 pub mod instances;
 pub mod launch;
 pub mod modpacks;
+pub mod settings;

--- a/src-tauri/src/commands/settings.rs
+++ b/src-tauri/src/commands/settings.rs
@@ -1,0 +1,35 @@
+use serde::Serialize;
+use tauri::State;
+
+use crate::error::LanternError;
+use crate::settings::Settings;
+use crate::state::AppState;
+
+#[derive(Serialize)]
+pub struct SettingsInfo {
+    pub data_dir: String,
+    pub default_data_dir: String,
+    pub data_dir_override: Option<String>,
+}
+
+#[tauri::command]
+pub fn get_settings(state: State<'_, AppState>) -> SettingsInfo {
+    let settings = Settings::load(&state.config_dir);
+    SettingsInfo {
+        data_dir: state.data_dir.to_string_lossy().to_string(),
+        default_data_dir: state.default_data_dir.to_string_lossy().to_string(),
+        data_dir_override: settings.data_dir,
+    }
+}
+
+#[tauri::command]
+pub fn set_data_dir(
+    state: State<'_, AppState>,
+    path: Option<String>,
+) -> Result<(), LanternError> {
+    let mut settings = Settings::load(&state.config_dir);
+    settings.data_dir = path;
+    settings
+        .save(&state.config_dir)
+        .map_err(|e| LanternError::Other(format!("Failed to save settings: {e}")))
+}

--- a/src-tauri/src/download/manager.rs
+++ b/src-tauri/src/download/manager.rs
@@ -3,6 +3,7 @@ use std::sync::Arc;
 
 use futures::StreamExt;
 use serde::Serialize;
+use sha1::Sha1;
 use sha2::{Digest, Sha512};
 use tokio::sync::Semaphore;
 
@@ -29,11 +30,18 @@ pub enum DownloadStatus {
     Failed,
 }
 
+#[derive(Debug, Clone)]
+pub enum ExpectedHash {
+    Sha512(String),
+    Sha1(String),
+    None,
+}
+
 pub struct DownloadTask {
     pub url: String,
     pub dest: PathBuf,
     pub expected_size: u64,
-    pub expected_sha512: Option<String>,
+    pub expected_hash: ExpectedHash,
     pub file_name: String,
 }
 
@@ -50,9 +58,26 @@ impl DownloadManager {
         }
     }
 
+    /// Download a file, verifying its hash. Overwrites if already exists.
     pub async fn download_file(&self, task: &DownloadTask) -> Result<(), LanternError> {
         let _permit = self.semaphore.acquire().await.unwrap();
+        self.download_inner(task).await
+    }
 
+    /// Download a file only if it doesn't already exist at the destination.
+    pub async fn download_if_missing(&self, task: &DownloadTask) -> Result<(), LanternError> {
+        if task.dest.exists() {
+            return Ok(());
+        }
+        let _permit = self.semaphore.acquire().await.unwrap();
+        // Re-check after acquiring permit (another task may have downloaded it)
+        if task.dest.exists() {
+            return Ok(());
+        }
+        self.download_inner(task).await
+    }
+
+    async fn download_inner(&self, task: &DownloadTask) -> Result<(), LanternError> {
         if let Some(parent) = task.dest.parent() {
             tokio::fs::create_dir_all(parent).await?;
         }
@@ -67,28 +92,53 @@ impl DownloadManager {
 
         let mut stream = response.bytes_stream();
         let mut file = tokio::fs::File::create(&part_path).await?;
-        let mut hasher = Sha512::new();
 
         use tokio::io::AsyncWriteExt;
-        while let Some(chunk) = stream.next().await {
-            let chunk = chunk?;
-            hasher.update(&chunk);
-            file.write_all(&chunk).await?;
-        }
+
+        let hash_hex = match &task.expected_hash {
+            ExpectedHash::Sha512(_) => {
+                let mut hasher = Sha512::new();
+                while let Some(chunk) = stream.next().await {
+                    let chunk = chunk?;
+                    hasher.update(&chunk);
+                    file.write_all(&chunk).await?;
+                }
+                format!("{:x}", hasher.finalize())
+            }
+            ExpectedHash::Sha1(_) => {
+                let mut hasher = Sha1::new();
+                while let Some(chunk) = stream.next().await {
+                    let chunk = chunk?;
+                    hasher.update(&chunk);
+                    file.write_all(&chunk).await?;
+                }
+                format!("{:x}", hasher.finalize())
+            }
+            ExpectedHash::None => {
+                while let Some(chunk) = stream.next().await {
+                    let chunk = chunk?;
+                    file.write_all(&chunk).await?;
+                }
+                String::new()
+            }
+        };
+
         file.flush().await?;
         drop(file);
 
         // Verify hash if expected
-        if let Some(expected) = &task.expected_sha512 {
-            let actual = format!("{:x}", hasher.finalize());
-            if &actual != expected {
-                let _ = tokio::fs::remove_file(&part_path).await;
-                return Err(LanternError::HashMismatch {
-                    file: task.file_name.clone(),
-                    expected: expected.clone(),
-                    actual,
-                });
+        match &task.expected_hash {
+            ExpectedHash::Sha512(expected) | ExpectedHash::Sha1(expected) => {
+                if &hash_hex != expected {
+                    let _ = tokio::fs::remove_file(&part_path).await;
+                    return Err(LanternError::HashMismatch {
+                        file: task.file_name.clone(),
+                        expected: expected.clone(),
+                        actual: hash_hex,
+                    });
+                }
             }
+            ExpectedHash::None => {}
         }
 
         tokio::fs::rename(&part_path, &task.dest).await?;

--- a/src-tauri/src/error.rs
+++ b/src-tauri/src/error.rs
@@ -20,6 +20,12 @@ pub enum LanternError {
     #[error("Instance error: {0}")]
     Instance(String),
 
+    #[error("Java error: {0}")]
+    Java(String),
+
+    #[error("Launch error: {0}")]
+    Launch(String),
+
     #[error("Hash mismatch for {file}: expected {expected}, got {actual}")]
     HashMismatch {
         file: String,
@@ -53,6 +59,8 @@ impl LanternError {
             Self::Json(_) => "json",
             Self::Auth(_) => "auth",
             Self::Instance(_) => "instance",
+            Self::Java(_) => "java",
+            Self::Launch(_) => "launch",
             Self::HashMismatch { .. } => "hash_mismatch",
             Self::Other(_) => "other",
         }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -35,6 +35,8 @@ pub fn run() {
             commands::file_locks::list_instance_files,
             commands::file_locks::set_file_lock,
             commands::file_locks::get_locked_files,
+            commands::install::install_modpack,
+            commands::launch::launch_instance,
         ])
         .run(tauri::generate_context!())
         .expect("error while running Lantern");

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -5,18 +5,24 @@ mod error;
 mod instance;
 mod minecraft;
 mod modrinth;
+mod settings;
 mod state;
 
+use settings::Settings;
 use state::AppState;
 
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 pub fn run() {
-    let data_dir = directories::ProjectDirs::from("com", "lantern", "Lantern")
-        .expect("Failed to determine data directory")
-        .data_dir()
-        .to_path_buf();
+    let dirs = directories::ProjectDirs::from("com", "lantern", "Lantern")
+        .expect("Failed to determine data directory");
+    let config_dir = dirs.config_dir().to_path_buf();
+    let default_data_dir = dirs.data_dir().to_path_buf();
 
-    let app_state = AppState::new(data_dir);
+    let settings = Settings::load(&config_dir);
+    let data_dir = settings.resolve_data_dir(&default_data_dir);
+    eprintln!("[init] Data directory: {}", data_dir.display());
+
+    let app_state = AppState::new(data_dir, config_dir, default_data_dir);
 
     tauri::Builder::default()
         .plugin(tauri_plugin_opener::init())
@@ -37,6 +43,8 @@ pub fn run() {
             commands::file_locks::get_locked_files,
             commands::install::install_modpack,
             commands::launch::launch_instance,
+            commands::settings::get_settings,
+            commands::settings::set_data_dir,
         ])
         .run(tauri::generate_context!())
         .expect("error while running Lantern");

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -26,6 +26,7 @@ pub fn run() {
 
     tauri::Builder::default()
         .plugin(tauri_plugin_opener::init())
+        .plugin(tauri_plugin_dialog::init())
         .manage(app_state)
         .invoke_handler(tauri::generate_handler![
             commands::auth::start_login,

--- a/src-tauri/src/minecraft/adoptium.rs
+++ b/src-tauri/src/minecraft/adoptium.rs
@@ -1,0 +1,140 @@
+use std::path::Path;
+
+use crate::error::LanternError;
+use crate::minecraft::java::JavaInfo;
+
+/// Download a JRE from Adoptium and extract it to data_dir/java/.
+pub async fn download_java(
+    client: &reqwest::Client,
+    data_dir: &Path,
+    major_version: u32,
+) -> Result<JavaInfo, LanternError> {
+    let os = adoptium_os();
+    let arch = adoptium_arch();
+
+    let url = format!(
+        "https://api.adoptium.net/v3/binary/latest/{major_version}/ga/{os}/{arch}/jre/hotspot/normal/eclipse"
+    );
+
+    eprintln!("[java] Downloading JRE {major_version} from Adoptium ({os}/{arch})...");
+
+    let response = client
+        .get(&url)
+        .send()
+        .await?
+        .error_for_status()
+        .map_err(|e| {
+            LanternError::Java(format!(
+                "Failed to download Java {major_version} from Adoptium: {e}"
+            ))
+        })?;
+
+    let java_dir = data_dir.join("java");
+    tokio::fs::create_dir_all(&java_dir).await?;
+
+    let archive_path = java_dir.join(format!("jre-{major_version}-download.tar.gz"));
+    let bytes = response.bytes().await?;
+    tokio::fs::write(&archive_path, &bytes).await?;
+
+    eprintln!("[java] Extracting JRE...");
+    let extract_dir = java_dir.clone();
+    let archive_path_clone = archive_path.clone();
+
+    // Extract in a blocking task since tar/flate2 are synchronous
+    let extracted_name = tokio::task::spawn_blocking(move || {
+        extract_tar_gz(&archive_path_clone, &extract_dir)
+    })
+    .await
+    .map_err(|e| LanternError::Java(format!("Extract task failed: {e}")))??;
+
+    // Clean up archive
+    let _ = tokio::fs::remove_file(&archive_path).await;
+
+    // Find the java binary in the extracted directory
+    let extracted_dir = java_dir.join(&extracted_name);
+    let java_bin = if cfg!(target_os = "macos") {
+        extracted_dir
+            .join("Contents")
+            .join("Home")
+            .join("bin")
+            .join("java")
+    } else {
+        extracted_dir.join("bin").join("java")
+    };
+
+    if !java_bin.exists() {
+        return Err(LanternError::Java(format!(
+            "Java binary not found at {}",
+            java_bin.display()
+        )));
+    }
+
+    // Make java executable on unix
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        let _ = std::fs::set_permissions(&java_bin, std::fs::Permissions::from_mode(0o755));
+    }
+
+    eprintln!("[java] JRE {major_version} installed at {}", extracted_dir.display());
+
+    Ok(JavaInfo {
+        path: java_bin,
+        version: format!("{major_version}"),
+        major_version,
+    })
+}
+
+fn extract_tar_gz(
+    archive_path: &std::path::Path,
+    extract_dir: &std::path::Path,
+) -> Result<String, LanternError> {
+    let file = std::fs::File::open(archive_path)?;
+    let decoder = flate2::read::GzDecoder::new(file);
+    let mut archive = tar::Archive::new(decoder);
+
+    // Find the top-level directory name from the first entry
+    let mut top_dir = String::new();
+
+    archive.unpack(extract_dir)?;
+
+    // Re-read to find the extracted directory name
+    let file = std::fs::File::open(archive_path)?;
+    let decoder = flate2::read::GzDecoder::new(file);
+    let mut archive = tar::Archive::new(decoder);
+
+    for entry in archive.entries()? {
+        let entry = entry?;
+        let path = entry.path()?;
+        if let Some(first) = path.components().next() {
+            top_dir = first.as_os_str().to_string_lossy().to_string();
+            break;
+        }
+    }
+
+    if top_dir.is_empty() {
+        return Err(LanternError::Java(
+            "Could not determine extracted directory name".into(),
+        ));
+    }
+
+    Ok(top_dir)
+}
+
+fn adoptium_os() -> &'static str {
+    if cfg!(target_os = "macos") {
+        "mac"
+    } else if cfg!(target_os = "windows") {
+        "windows"
+    } else {
+        "linux"
+    }
+}
+
+fn adoptium_arch() -> &'static str {
+    if cfg!(target_arch = "aarch64") {
+        "aarch64"
+    } else {
+        "x64"
+    }
+}

--- a/src-tauri/src/minecraft/fabric.rs
+++ b/src-tauri/src/minecraft/fabric.rs
@@ -1,0 +1,54 @@
+use std::path::{Path, PathBuf};
+
+use crate::error::LanternError;
+
+const FABRIC_META_URL: &str = "https://meta.fabricmc.net/v2";
+
+/// Download the Fabric loader profile JSON and save it to the versions directory.
+/// Returns the path to the saved JSON file.
+pub async fn install_fabric(
+    client: &reqwest::Client,
+    data_dir: &Path,
+    mc_version: &str,
+    loader_version: &str,
+) -> Result<PathBuf, LanternError> {
+    let version_id = format!("{mc_version}-fabric-{loader_version}");
+    let version_dir = data_dir.join("versions").join(&version_id);
+    let json_path = version_dir.join(format!("{version_id}.json"));
+
+    // Already installed
+    if json_path.exists() {
+        eprintln!("[fabric] Profile already exists: {version_id}");
+        return Ok(json_path);
+    }
+
+    let url = format!(
+        "{FABRIC_META_URL}/versions/loader/{mc_version}/{loader_version}/profile/json"
+    );
+
+    eprintln!("[fabric] Downloading profile: {version_id}");
+
+    let text = client
+        .get(&url)
+        .send()
+        .await?
+        .error_for_status()
+        .map_err(|e| {
+            LanternError::Other(format!(
+                "Failed to download Fabric profile for {mc_version}/{loader_version}: {e}"
+            ))
+        })?
+        .text()
+        .await?;
+
+    // Validate that it parses
+    let _: super::version::VersionJson = serde_json::from_str(&text).map_err(|e| {
+        LanternError::Other(format!("Invalid Fabric profile JSON: {e}"))
+    })?;
+
+    tokio::fs::create_dir_all(&version_dir).await?;
+    tokio::fs::write(&json_path, &text).await?;
+
+    eprintln!("[fabric] Installed: {version_id}");
+    Ok(json_path)
+}

--- a/src-tauri/src/minecraft/install.rs
+++ b/src-tauri/src/minecraft/install.rs
@@ -1,0 +1,374 @@
+use std::collections::HashMap;
+use std::sync::atomic::{AtomicU32, Ordering};
+use std::sync::Arc;
+
+use serde::Serialize;
+use tauri::{AppHandle, Emitter};
+
+use crate::download::manager::{DownloadManager, DownloadTask, ExpectedHash};
+use crate::error::LanternError;
+use crate::instance::manager::{Instance, ModLoader, ModpackInfo};
+use crate::modrinth::api::ModrinthApi;
+use crate::modrinth::mrpack::{extract_overrides, parse_mrpack};
+use crate::modrinth::types::EnvSupport;
+use crate::state::AppState;
+
+#[derive(Debug, Clone, Serialize)]
+pub struct InstallProgress {
+    pub stage: InstallStage,
+    pub message: String,
+    pub current: u32,
+    pub total: u32,
+    pub bytes_downloaded: u64,
+    pub bytes_total: u64,
+    pub project_id: String,
+}
+
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum InstallStage {
+    Downloading,
+    Parsing,
+    InstallingMods,
+    ExtractingOverrides,
+    InstallingLoader,
+    Finalizing,
+    Complete,
+    Failed,
+}
+
+fn emit_progress(app: &AppHandle, progress: &InstallProgress) {
+    let _ = app.emit("install-progress", progress);
+}
+
+pub async fn install_modpack(
+    app: AppHandle,
+    state: &AppState,
+    project_id: String,
+    version_id: String,
+) -> Result<Instance, LanternError> {
+    let client = &state.http_client;
+    let api = ModrinthApi::new(client.clone());
+
+    // Fetch project + version info
+    let project = api.get_project(&project_id).await?;
+    let version = api.get_version(&version_id).await?;
+
+    let primary_file = version
+        .files
+        .iter()
+        .find(|f| f.primary)
+        .or_else(|| version.files.first())
+        .ok_or_else(|| LanternError::Other("No files in version".into()))?;
+
+    // Stage: Downloading mrpack
+    emit_progress(
+        &app,
+        &InstallProgress {
+            stage: InstallStage::Downloading,
+            message: format!("Downloading {}...", primary_file.filename),
+            current: 0,
+            total: 1,
+            bytes_downloaded: 0,
+            bytes_total: primary_file.size,
+            project_id: project_id.clone(),
+        },
+    );
+
+    let temp_dir = state.data_dir.join("temp");
+    tokio::fs::create_dir_all(&temp_dir).await?;
+    let mrpack_path = temp_dir.join(&primary_file.filename);
+
+    let dm = DownloadManager::new(client.clone());
+    dm.download_file(&DownloadTask {
+        url: primary_file.url.clone(),
+        dest: mrpack_path.clone(),
+        expected_size: primary_file.size,
+        expected_hash: primary_file
+            .hashes
+            .sha512
+            .as_ref()
+            .map(|h| ExpectedHash::Sha512(h.clone()))
+            .unwrap_or(ExpectedHash::None),
+        file_name: primary_file.filename.clone(),
+    })
+    .await?;
+
+    // Stage: Parsing
+    emit_progress(
+        &app,
+        &InstallProgress {
+            stage: InstallStage::Parsing,
+            message: "Reading modpack contents...".into(),
+            current: 0,
+            total: 0,
+            bytes_downloaded: 0,
+            bytes_total: 0,
+            project_id: project_id.clone(),
+        },
+    );
+
+    let mrpack_path_clone = mrpack_path.clone();
+    let index =
+        tokio::task::spawn_blocking(move || parse_mrpack(&mrpack_path_clone))
+            .await
+            .map_err(|e| LanternError::Other(format!("Parse task failed: {e}")))??;
+
+    // Read dependencies
+    let mc_version = index
+        .dependencies
+        .get("minecraft")
+        .cloned()
+        .ok_or_else(|| LanternError::Other("Modpack has no minecraft dependency".into()))?;
+
+    let fabric_version = index.dependencies.get("fabric-loader").cloned();
+    let quilt_version = index.dependencies.get("quilt-loader").cloned();
+    let forge_version = index.dependencies.get("forge").cloned();
+    let neoforge_version = index.dependencies.get("neoforge").cloned();
+
+    let (loader, loader_version) = if let Some(v) = &fabric_version {
+        (ModLoader::Fabric, Some(v.clone()))
+    } else if let Some(v) = &quilt_version {
+        (ModLoader::Quilt, Some(v.clone()))
+    } else if let Some(v) = &forge_version {
+        (ModLoader::Forge, Some(v.clone()))
+    } else if let Some(v) = &neoforge_version {
+        (ModLoader::NeoForge, Some(v.clone()))
+    } else {
+        (ModLoader::Vanilla, None)
+    };
+
+    // Create instance
+    let instance_id = uuid::Uuid::new_v4().to_string();
+    let minecraft_dir = state
+        .data_dir
+        .join("instances")
+        .join(&instance_id)
+        .join(".minecraft");
+    tokio::fs::create_dir_all(&minecraft_dir).await?;
+
+    // Stage: Installing mods
+    // Filter files: skip server-only
+    let mod_files: Vec<_> = index
+        .files
+        .iter()
+        .filter(|f| {
+            f.env
+                .as_ref()
+                .map_or(true, |env| env.client != EnvSupport::Unsupported)
+        })
+        .collect();
+
+    let total_files = mod_files.len() as u32;
+    let total_bytes: u64 = mod_files.iter().map(|f| f.file_size).sum();
+    let completed = Arc::new(AtomicU32::new(0));
+
+    emit_progress(
+        &app,
+        &InstallProgress {
+            stage: InstallStage::InstallingMods,
+            message: format!("Downloading files (0 of {total_files})..."),
+            current: 0,
+            total: total_files,
+            bytes_downloaded: 0,
+            bytes_total: total_bytes,
+            project_id: project_id.clone(),
+        },
+    );
+
+    // Build download tasks
+    let mut tasks = Vec::new();
+    let mut file_hashes: HashMap<String, String> = HashMap::new();
+
+    for mf in &mod_files {
+        let url = mf
+            .downloads
+            .first()
+            .ok_or_else(|| {
+                LanternError::Other(format!("No download URL for {}", mf.path))
+            })?
+            .clone();
+
+        let dest = minecraft_dir.join(&mf.path);
+
+        file_hashes.insert(mf.path.clone(), mf.hashes.sha512.clone());
+
+        tasks.push(DownloadTask {
+            url,
+            dest,
+            expected_size: mf.file_size,
+            expected_hash: ExpectedHash::Sha512(mf.hashes.sha512.clone()),
+            file_name: mf
+                .path
+                .rsplit('/')
+                .next()
+                .unwrap_or(&mf.path)
+                .to_string(),
+        });
+    }
+
+    // Download all files concurrently
+    let mut handles = Vec::new();
+    for task in tasks {
+        let dm = DownloadManager::new(client.clone());
+        let completed = Arc::clone(&completed);
+        let app_clone = app.clone();
+        let project_id_clone = project_id.clone();
+
+        handles.push(tokio::spawn(async move {
+            dm.download_file(&task).await?;
+
+            let done = completed.fetch_add(1, Ordering::Relaxed) + 1;
+            emit_progress(
+                &app_clone,
+                &InstallProgress {
+                    stage: InstallStage::InstallingMods,
+                    message: format!("Downloading files ({done} of {total_files})..."),
+                    current: done,
+                    total: total_files,
+                    bytes_downloaded: 0, // simplified — we track by file count
+                    bytes_total: total_bytes,
+                    project_id: project_id_clone,
+                },
+            );
+
+            Ok::<(), LanternError>(())
+        }));
+    }
+
+    for handle in handles {
+        handle
+            .await
+            .map_err(|e| LanternError::Other(format!("Download task panicked: {e}")))??;
+    }
+
+    // Stage: Extracting overrides
+    emit_progress(
+        &app,
+        &InstallProgress {
+            stage: InstallStage::ExtractingOverrides,
+            message: "Extracting pack files...".into(),
+            current: 0,
+            total: 0,
+            bytes_downloaded: 0,
+            bytes_total: 0,
+            project_id: project_id.clone(),
+        },
+    );
+
+    let mc_dir_clone = minecraft_dir.clone();
+    let mrpack_path_clone2 = mrpack_path.clone();
+    let extracted = tokio::task::spawn_blocking(move || {
+        extract_overrides(
+            &mrpack_path_clone2,
+            &mc_dir_clone,
+            &std::collections::HashSet::new(),
+        )
+    })
+    .await
+    .map_err(|e| LanternError::Other(format!("Extract task failed: {e}")))??;
+
+    // Add extracted override files to manifest
+    for path in &extracted {
+        // We don't have hashes for overrides, so use empty string
+        file_hashes.insert(path.clone(), String::new());
+    }
+
+    // Stage: Installing loader
+    if let Some(ref fv) = fabric_version {
+        emit_progress(
+            &app,
+            &InstallProgress {
+                stage: InstallStage::InstallingLoader,
+                message: format!("Installing Fabric {fv}..."),
+                current: 0,
+                total: 1,
+                bytes_downloaded: 0,
+                bytes_total: 0,
+                project_id: project_id.clone(),
+            },
+        );
+
+        super::fabric::install_fabric(client, &state.data_dir, &mc_version, fv).await?;
+    }
+
+    // Stage: Finalizing
+    emit_progress(
+        &app,
+        &InstallProgress {
+            stage: InstallStage::Finalizing,
+            message: "Saving modpack data...".into(),
+            current: 0,
+            total: 0,
+            bytes_downloaded: 0,
+            bytes_total: 0,
+            project_id: project_id.clone(),
+        },
+    );
+
+    // Write file_manifest.json
+    let manifest = serde_json::to_string_pretty(&file_hashes)?;
+    let instance_dir = state.data_dir.join("instances").join(&instance_id);
+    tokio::fs::write(instance_dir.join("file_manifest.json"), manifest).await?;
+
+    // Write last_mrpack_index.json (copy of the modrinth.index.json)
+    let mrpack_path_clone3 = mrpack_path.clone();
+    let index_json = tokio::task::spawn_blocking(move || -> Result<String, LanternError> {
+        let file = std::fs::File::open(&mrpack_path_clone3)?;
+        let mut archive = zip::ZipArchive::new(file)?;
+        let mut index_entry = archive.by_name("modrinth.index.json")?;
+        let mut contents = String::new();
+        std::io::Read::read_to_string(&mut index_entry, &mut contents)?;
+        Ok(contents)
+    })
+    .await
+    .map_err(|e| LanternError::Other(format!("Read index task failed: {e}")))??;
+
+    tokio::fs::write(instance_dir.join("last_mrpack_index.json"), index_json).await?;
+
+    // Clean up mrpack temp file
+    let _ = tokio::fs::remove_file(&mrpack_path).await;
+
+    // Create and save instance
+    let instance = Instance {
+        id: instance_id,
+        name: project.title.clone(),
+        minecraft_version: mc_version,
+        loader,
+        loader_version,
+        modpack: Some(ModpackInfo {
+            project_id: project.id.clone(),
+            version_id: version.id.clone(),
+            version_name: version.name.clone(),
+            project_slug: project.slug.clone(),
+            name: project.title.clone(),
+            icon_url: project.icon_url.clone(),
+        }),
+        locked_files: std::collections::HashSet::new(),
+        created_at: chrono::Utc::now(),
+        last_played: None,
+        jvm_args: Vec::new(),
+        memory_mb: 4096,
+    };
+
+    {
+        let instances = state.instances.lock().unwrap();
+        instances.save(&instance)?;
+    }
+
+    // Stage: Complete
+    emit_progress(
+        &app,
+        &InstallProgress {
+            stage: InstallStage::Complete,
+            message: format!("{} installed!", project.title),
+            current: total_files,
+            total: total_files,
+            bytes_downloaded: total_bytes,
+            bytes_total: total_bytes,
+            project_id: project_id.clone(),
+        },
+    );
+
+    Ok(instance)
+}

--- a/src-tauri/src/minecraft/java.rs
+++ b/src-tauri/src/minecraft/java.rs
@@ -1,36 +1,122 @@
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::process::Command;
 
 use crate::error::LanternError;
 
-pub fn detect_java() -> Option<JavaInfo> {
-    // Try JAVA_HOME first
-    if let Ok(java_home) = std::env::var("JAVA_HOME") {
-        let java_path = PathBuf::from(&java_home).join("bin").join("java");
-        if let Some(info) = probe_java(&java_path) {
-            return Some(info);
-        }
-    }
-
-    // Try system java
-    if let Some(info) = probe_java(&PathBuf::from("java")) {
-        return Some(info);
-    }
-
-    None
-}
-
+#[derive(Debug)]
 pub struct JavaInfo {
     pub path: PathBuf,
     pub version: String,
     pub major_version: u32,
 }
 
+/// Detect all available Java installations.
+pub fn detect_all_java(data_dir: &Path) -> Vec<JavaInfo> {
+    let mut found = Vec::new();
+
+    // Check JAVA_HOME
+    if let Ok(java_home) = std::env::var("JAVA_HOME") {
+        let java_path = PathBuf::from(&java_home).join("bin").join("java");
+        if let Some(info) = probe_java(&java_path) {
+            found.push(info);
+        }
+    }
+
+    // Check system java
+    if let Some(info) = probe_java(&PathBuf::from("java")) {
+        if !found.iter().any(|j: &JavaInfo| j.major_version == info.major_version) {
+            found.push(info);
+        }
+    }
+
+    // Check common macOS paths
+    #[cfg(target_os = "macos")]
+    {
+        if let Ok(entries) = std::fs::read_dir("/Library/Java/JavaVirtualMachines") {
+            for entry in entries.flatten() {
+                let java_path = entry
+                    .path()
+                    .join("Contents")
+                    .join("Home")
+                    .join("bin")
+                    .join("java");
+                if java_path.exists() {
+                    if let Some(info) = probe_java(&java_path) {
+                        if !found.iter().any(|j| j.major_version == info.major_version) {
+                            found.push(info);
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    // Check common Linux paths
+    #[cfg(target_os = "linux")]
+    {
+        if let Ok(entries) = std::fs::read_dir("/usr/lib/jvm") {
+            for entry in entries.flatten() {
+                let java_path = entry.path().join("bin").join("java");
+                if java_path.exists() {
+                    if let Some(info) = probe_java(&java_path) {
+                        if !found.iter().any(|j| j.major_version == info.major_version) {
+                            found.push(info);
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    // Check Lantern-managed Java (Adoptium downloads)
+    let java_dir = data_dir.join("java");
+    if let Ok(entries) = std::fs::read_dir(&java_dir) {
+        for entry in entries.flatten() {
+            let java_path = if cfg!(target_os = "macos") {
+                entry
+                    .path()
+                    .join("Contents")
+                    .join("Home")
+                    .join("bin")
+                    .join("java")
+            } else {
+                entry.path().join("bin").join("java")
+            };
+            if java_path.exists() {
+                if let Some(info) = probe_java(&java_path) {
+                    if !found.iter().any(|j| j.major_version == info.major_version) {
+                        found.push(info);
+                    }
+                }
+            }
+        }
+    }
+
+    found
+}
+
+/// Find a suitable Java for the given Minecraft version, downloading if needed.
+pub async fn ensure_java(
+    client: &reqwest::Client,
+    data_dir: &Path,
+    minecraft_version: &str,
+) -> Result<JavaInfo, LanternError> {
+    let required = required_java_version(minecraft_version);
+    let all = detect_all_java(data_dir);
+
+    // Prefer exact match, then any version >= required
+    if let Some(info) = all.into_iter().find(|j| j.major_version == required) {
+        return Ok(info);
+    }
+
+    eprintln!("[java] No Java {required} found, downloading from Adoptium...");
+    super::adoptium::download_java(client, data_dir, required).await
+}
+
 fn probe_java(path: &PathBuf) -> Option<JavaInfo> {
     let output = Command::new(path).arg("-version").output().ok()?;
     let stderr = String::from_utf8_lossy(&output.stderr);
 
-    // Parse version from output like: openjdk version "21.0.1" or java version "1.8.0_301"
     let version_line = stderr.lines().next()?;
     let version = version_line.split('"').nth(1)?.to_string();
 
@@ -46,7 +132,6 @@ fn probe_java(path: &PathBuf) -> Option<JavaInfo> {
 fn parse_major_version(version: &str) -> Option<u32> {
     let first_part = version.split('.').next()?;
     let major: u32 = first_part.parse().ok()?;
-    // Java 1.8 -> major 8, Java 21 -> major 21
     if major == 1 {
         version.split('.').nth(1)?.parse().ok()
     } else {
@@ -61,9 +146,9 @@ pub fn required_java_version(minecraft_version: &str) -> u32 {
         .collect();
 
     match (parts.first(), parts.get(1)) {
-        (Some(1), Some(minor)) if *minor >= 21 => 21, // 1.21+
-        (Some(1), Some(minor)) if *minor >= 18 => 17, // 1.18-1.20.x
-        (Some(1), Some(minor)) if *minor >= 17 => 16, // 1.17
-        _ => 8,                                       // 1.16 and below
+        (Some(1), Some(minor)) if *minor >= 21 => 21,
+        (Some(1), Some(minor)) if *minor >= 18 => 17,
+        (Some(1), Some(minor)) if *minor >= 17 => 16,
+        _ => 8,
     }
 }

--- a/src-tauri/src/minecraft/launch.rs
+++ b/src-tauri/src/minecraft/launch.rs
@@ -162,6 +162,9 @@ pub async fn launch_instance(
     subs.insert("version_type", version_json.version_type.clone());
     subs.insert("classpath_separator", classpath_separator().into());
     subs.insert("library_directory", data_dir.join("libraries").to_string_lossy().to_string());
+    // Microsoft auth extras (plain args in modern version JSONs)
+    subs.insert("clientid", "00000000402b5328".into());
+    subs.insert("auth_xuid", "0".into());
 
     let jvm_args = resolve_jvm_arguments(&version_json, &subs);
     let game_args = resolve_game_arguments(&version_json, &subs);

--- a/src-tauri/src/minecraft/launch.rs
+++ b/src-tauri/src/minecraft/launch.rs
@@ -173,11 +173,18 @@ pub async fn launch_instance(
     ];
     memory_args.extend(instance.jvm_args.clone());
 
-    // 10. Spawn process
+    // 10. Ensure game directory exists
+    tokio::fs::create_dir_all(&minecraft_dir).await?;
+
+    // 11. Spawn process
     // Command: java [memory_args] [jvm_args] MainClass [game_args]
     eprintln!("[launch] Starting Minecraft...");
     eprintln!("[launch] Java: {}", java.path.display());
     eprintln!("[launch] Main class: {}", version_json.main_class);
+    eprintln!("[launch] Game dir: {}", minecraft_dir.display());
+    eprintln!("[launch] JVM args: {:?}", jvm_args);
+    eprintln!("[launch] Memory args: {:?}", memory_args);
+    eprintln!("[launch] Game args: {:?}", game_args);
 
     let mut cmd = Command::new(&java.path);
     cmd.args(&memory_args);

--- a/src-tauri/src/minecraft/launch.rs
+++ b/src-tauri/src/minecraft/launch.rs
@@ -1,0 +1,440 @@
+use std::collections::HashMap;
+use std::path::{Path, PathBuf};
+
+use serde::Serialize;
+use tauri::{AppHandle, Emitter};
+use tokio::io::{AsyncBufReadExt, BufReader};
+use tokio::process::Command;
+
+use crate::download::manager::{DownloadManager, DownloadTask, ExpectedHash};
+use crate::error::LanternError;
+use crate::instance::manager::{Instance, ModLoader};
+use crate::state::AppState;
+
+use super::version::*;
+
+#[derive(Clone, Serialize)]
+struct GameStarted {
+    instance_id: String,
+}
+
+#[derive(Clone, Serialize)]
+struct GameLog {
+    instance_id: String,
+    line: String,
+    stream: String,
+}
+
+#[derive(Clone, Serialize)]
+struct GameExit {
+    instance_id: String,
+    exit_code: Option<i32>,
+}
+
+pub async fn launch_instance(
+    app: AppHandle,
+    state: &AppState,
+    instance: &Instance,
+    online: bool,
+    auth_name: Option<String>,
+    auth_uuid: Option<String>,
+    auth_token: Option<String>,
+) -> Result<(), LanternError> {
+    let client = &state.http_client;
+    let data_dir = &state.data_dir;
+
+    // 1. Resolve Java
+    eprintln!("[launch] Resolving Java for MC {}...", instance.minecraft_version);
+    let java = super::java::ensure_java(client, data_dir, &instance.minecraft_version).await?;
+    eprintln!("[launch] Using Java {} at {}", java.version, java.path.display());
+
+    // 2. Fetch version manifest + version JSON
+    let manifest = fetch_version_manifest(client).await?;
+    let manifest_entry = manifest
+        .versions
+        .iter()
+        .find(|v| v.id == instance.minecraft_version)
+        .ok_or_else(|| {
+            LanternError::Launch(format!(
+                "Minecraft version {} not found in manifest",
+                instance.minecraft_version
+            ))
+        })?;
+
+    let vanilla_json =
+        fetch_version_json(client, data_dir, &instance.minecraft_version, &manifest_entry.url)
+            .await?;
+
+    // 3. If using a mod loader, merge version JSONs
+    let version_json = match (&instance.loader, &instance.loader_version) {
+        (ModLoader::Fabric, Some(loader_ver)) => {
+            let fabric_json_path = super::fabric::install_fabric(
+                client,
+                data_dir,
+                &instance.minecraft_version,
+                loader_ver,
+            )
+            .await?;
+
+            let fabric_json = load_version_json(&fabric_json_path).await?;
+            merge_version_json(fabric_json, vanilla_json)
+        }
+        _ => vanilla_json,
+    };
+
+    // 4. Download client JAR
+    let client_jar = download_client_jar(client, data_dir, &instance.minecraft_version, &version_json).await?;
+
+    // 5. Download libraries
+    let library_paths = download_libraries(client, data_dir, &version_json).await?;
+
+    // 6. Download assets
+    if let Some(ref asset_ref) = version_json.asset_index {
+        download_assets(client, data_dir, asset_ref).await?;
+    }
+
+    // 7. Build classpath
+    let classpath = build_classpath(&library_paths, &client_jar);
+
+    // 8. Build arguments
+    let minecraft_dir = state
+        .data_dir
+        .join("instances")
+        .join(&instance.id)
+        .join(".minecraft");
+
+    let natives_dir = data_dir
+        .join("versions")
+        .join(&instance.minecraft_version)
+        .join("natives");
+    tokio::fs::create_dir_all(&natives_dir).await?;
+
+    let player_name = if online {
+        auth_name.unwrap_or_else(|| "Player".into())
+    } else {
+        auth_name.unwrap_or_else(|| "Player".into())
+    };
+
+    let player_uuid = if online {
+        auth_uuid.unwrap_or_else(|| "0".repeat(32))
+    } else {
+        // Generate offline UUID from username
+        offline_uuid(&player_name)
+    };
+
+    let access_token = if online {
+        auth_token.unwrap_or_default()
+    } else {
+        "0".into()
+    };
+
+    let asset_index_id = version_json
+        .asset_index
+        .as_ref()
+        .map(|a| a.id.clone())
+        .unwrap_or_else(|| instance.minecraft_version.clone());
+
+    let mut subs: HashMap<&str, String> = HashMap::new();
+    subs.insert("natives_directory", natives_dir.to_string_lossy().to_string());
+    subs.insert("launcher_name", "Lantern".into());
+    subs.insert("launcher_version", "0.1.0".into());
+    subs.insert("classpath", classpath);
+    subs.insert("auth_player_name", player_name);
+    subs.insert("version_name", version_json.id.clone());
+    subs.insert("game_directory", minecraft_dir.to_string_lossy().to_string());
+    subs.insert(
+        "assets_root",
+        data_dir.join("assets").to_string_lossy().to_string(),
+    );
+    subs.insert("assets_index_name", asset_index_id);
+    subs.insert("auth_uuid", player_uuid);
+    subs.insert("auth_access_token", access_token);
+    subs.insert(
+        "user_type",
+        if online { "msa" } else { "legacy" }.into(),
+    );
+    subs.insert("version_type", version_json.version_type.clone());
+    subs.insert("classpath_separator", classpath_separator().into());
+    subs.insert("library_directory", data_dir.join("libraries").to_string_lossy().to_string());
+
+    let args = resolve_arguments(&version_json, &subs);
+
+    // 9. Build memory args
+    let mut jvm_extra = vec![
+        format!("-Xmx{}m", instance.memory_mb),
+        format!("-Xms{}m", instance.memory_mb / 2),
+    ];
+    jvm_extra.extend(instance.jvm_args.clone());
+
+    // 10. Spawn process
+    eprintln!("[launch] Starting Minecraft...");
+    eprintln!("[launch] Java: {}", java.path.display());
+    eprintln!("[launch] Main class: {}", version_json.main_class);
+
+    let mut cmd = Command::new(&java.path);
+    cmd.args(&jvm_extra);
+    cmd.args(&args);
+    cmd.arg(&version_json.main_class);
+    cmd.current_dir(&minecraft_dir);
+    cmd.stdout(std::process::Stdio::piped());
+    cmd.stderr(std::process::Stdio::piped());
+
+    let mut child = cmd.spawn().map_err(|e| {
+        LanternError::Launch(format!("Failed to start Minecraft: {e}"))
+    })?;
+
+    let instance_id = instance.id.clone();
+    let _ = app.emit("game-started", GameStarted {
+        instance_id: instance_id.clone(),
+    });
+
+    // 11. Stream logs in background
+    let stdout = child.stdout.take();
+    let stderr = child.stderr.take();
+
+    let app_stdout = app.clone();
+    let id_stdout = instance_id.clone();
+    if let Some(stdout) = stdout {
+        tokio::spawn(async move {
+            let reader = BufReader::new(stdout);
+            let mut lines = reader.lines();
+            while let Ok(Some(line)) = lines.next_line().await {
+                let _ = app_stdout.emit(
+                    "game-log",
+                    GameLog {
+                        instance_id: id_stdout.clone(),
+                        line,
+                        stream: "stdout".into(),
+                    },
+                );
+            }
+        });
+    }
+
+    let app_stderr = app.clone();
+    let id_stderr = instance_id.clone();
+    if let Some(stderr) = stderr {
+        tokio::spawn(async move {
+            let reader = BufReader::new(stderr);
+            let mut lines = reader.lines();
+            while let Ok(Some(line)) = lines.next_line().await {
+                let _ = app_stderr.emit(
+                    "game-log",
+                    GameLog {
+                        instance_id: id_stderr.clone(),
+                        line,
+                        stream: "stderr".into(),
+                    },
+                );
+            }
+        });
+    }
+
+    // 12. Wait for exit in background
+    let app_exit = app.clone();
+    let id_exit = instance_id;
+    tokio::spawn(async move {
+        let status = child.wait().await;
+        let exit_code = status.ok().and_then(|s| s.code());
+        eprintln!("[launch] Minecraft exited with code: {exit_code:?}");
+        let _ = app_exit.emit(
+            "game-exit",
+            GameExit {
+                instance_id: id_exit,
+                exit_code,
+            },
+        );
+    });
+
+    Ok(())
+}
+
+async fn download_client_jar(
+    client: &reqwest::Client,
+    data_dir: &Path,
+    version_id: &str,
+    version_json: &VersionJson,
+) -> Result<PathBuf, LanternError> {
+    let jar_path = data_dir
+        .join("versions")
+        .join(version_id)
+        .join(format!("{version_id}.jar"));
+
+    if jar_path.exists() {
+        return Ok(jar_path);
+    }
+
+    let downloads = version_json
+        .downloads
+        .as_ref()
+        .ok_or_else(|| LanternError::Launch("Version JSON has no downloads section".into()))?;
+
+    eprintln!("[launch] Downloading client JAR...");
+    let dm = DownloadManager::new(client.clone());
+    dm.download_file(&DownloadTask {
+        url: downloads.client.url.clone(),
+        dest: jar_path.clone(),
+        expected_size: downloads.client.size,
+        expected_hash: ExpectedHash::Sha1(downloads.client.sha1.clone()),
+        file_name: format!("{version_id}.jar"),
+    })
+    .await?;
+
+    Ok(jar_path)
+}
+
+async fn download_libraries(
+    client: &reqwest::Client,
+    data_dir: &Path,
+    version_json: &VersionJson,
+) -> Result<Vec<PathBuf>, LanternError> {
+    let libraries = filter_libraries(&version_json.libraries);
+    let libraries_dir = data_dir.join("libraries");
+
+    let mut paths = Vec::new();
+    let mut handles = Vec::new();
+
+    for lib in &libraries {
+        // Get download info from explicit downloads or construct from Maven coords
+        let (url, path, sha1, size) = if let Some(ref dl) = lib.downloads {
+            if let Some(ref artifact) = dl.artifact {
+                (
+                    artifact.url.clone(),
+                    artifact.path.clone(),
+                    Some(artifact.sha1.clone()),
+                    artifact.size,
+                )
+            } else {
+                continue; // no artifact to download
+            }
+        } else if let Some(ref base_url) = lib.url {
+            // Fabric-style: url base + maven path
+            if let Some(maven_path) = maven_to_path(&lib.name) {
+                let url = format!("{}{}", base_url, maven_path);
+                (url, maven_path, None, 0)
+            } else {
+                continue;
+            }
+        } else if let Some(maven_path) = maven_to_path(&lib.name) {
+            // Default to Mojang's Maven repo
+            let url = format!("https://libraries.minecraft.net/{maven_path}");
+            (url, maven_path, None, 0)
+        } else {
+            continue;
+        };
+
+        let dest = libraries_dir.join(&path);
+        paths.push(dest.clone());
+
+        if dest.exists() {
+            continue;
+        }
+
+        let dm = DownloadManager::new(client.clone());
+        let hash = sha1
+            .map(ExpectedHash::Sha1)
+            .unwrap_or(ExpectedHash::None);
+
+        handles.push(tokio::spawn(async move {
+            dm.download_file(&DownloadTask {
+                url,
+                dest,
+                expected_size: size,
+                expected_hash: hash,
+                file_name: path,
+            })
+            .await
+        }));
+    }
+
+    if !handles.is_empty() {
+        eprintln!("[launch] Downloading {} libraries...", handles.len());
+    }
+
+    for handle in handles {
+        handle
+            .await
+            .map_err(|e| LanternError::Launch(format!("Library download panicked: {e}")))??;
+    }
+
+    Ok(paths)
+}
+
+async fn download_assets(
+    client: &reqwest::Client,
+    data_dir: &Path,
+    asset_ref: &AssetIndexRef,
+) -> Result<(), LanternError> {
+    let index = fetch_asset_index(client, data_dir, asset_ref).await?;
+
+    let objects_dir = data_dir.join("assets").join("objects");
+    let mut handles = Vec::new();
+
+    for (_name, obj) in &index.objects {
+        let prefix = &obj.hash[..2];
+        let dest = objects_dir.join(prefix).join(&obj.hash);
+
+        if dest.exists() {
+            continue;
+        }
+
+        let url = format!(
+            "https://resources.download.minecraft.net/{}/{}",
+            prefix, obj.hash
+        );
+        let hash = obj.hash.clone();
+        let size = obj.size;
+
+        let dm = DownloadManager::new(client.clone());
+        handles.push(tokio::spawn(async move {
+            dm.download_file(&DownloadTask {
+                url,
+                dest,
+                expected_size: size,
+                expected_hash: ExpectedHash::Sha1(hash.clone()),
+                file_name: hash,
+            })
+            .await
+        }));
+    }
+
+    if !handles.is_empty() {
+        eprintln!("[launch] Downloading {} assets...", handles.len());
+    }
+
+    for handle in handles {
+        handle
+            .await
+            .map_err(|e| LanternError::Launch(format!("Asset download panicked: {e}")))??;
+    }
+
+    Ok(())
+}
+
+fn build_classpath(library_paths: &[PathBuf], client_jar: &Path) -> String {
+    let sep = classpath_separator();
+    let mut parts: Vec<String> = library_paths
+        .iter()
+        .map(|p| p.to_string_lossy().to_string())
+        .collect();
+    parts.push(client_jar.to_string_lossy().to_string());
+    parts.join(sep)
+}
+
+fn classpath_separator() -> &'static str {
+    if cfg!(target_os = "windows") {
+        ";"
+    } else {
+        ":"
+    }
+}
+
+fn offline_uuid(username: &str) -> String {
+    // Minecraft offline UUIDs are v3 UUIDs based on "OfflinePlayer:" + username
+    use sha2::Digest;
+    let mut hasher = sha2::Sha256::new();
+    hasher.update(format!("OfflinePlayer:{username}").as_bytes());
+    let hash = format!("{:x}", hasher.finalize());
+    // Take first 32 hex chars
+    hash[..32].to_string()
+}

--- a/src-tauri/src/minecraft/launch.rs
+++ b/src-tauri/src/minecraft/launch.rs
@@ -11,7 +11,11 @@ use crate::error::LanternError;
 use crate::instance::manager::{Instance, ModLoader};
 use crate::state::AppState;
 
-use super::version::*;
+use super::version::{
+    fetch_asset_index, fetch_version_json, fetch_version_manifest, filter_libraries,
+    load_version_json, maven_to_path, merge_version_json, resolve_game_arguments,
+    resolve_jvm_arguments, AssetIndexRef, VersionJson,
+};
 
 #[derive(Clone, Serialize)]
 struct GameStarted {
@@ -157,24 +161,27 @@ pub async fn launch_instance(
     subs.insert("classpath_separator", classpath_separator().into());
     subs.insert("library_directory", data_dir.join("libraries").to_string_lossy().to_string());
 
-    let args = resolve_arguments(&version_json, &subs);
+    let jvm_args = resolve_jvm_arguments(&version_json, &subs);
+    let game_args = resolve_game_arguments(&version_json, &subs);
 
     // 9. Build memory args
-    let mut jvm_extra = vec![
+    let mut memory_args = vec![
         format!("-Xmx{}m", instance.memory_mb),
         format!("-Xms{}m", instance.memory_mb / 2),
     ];
-    jvm_extra.extend(instance.jvm_args.clone());
+    memory_args.extend(instance.jvm_args.clone());
 
     // 10. Spawn process
+    // Command: java [memory_args] [jvm_args] MainClass [game_args]
     eprintln!("[launch] Starting Minecraft...");
     eprintln!("[launch] Java: {}", java.path.display());
     eprintln!("[launch] Main class: {}", version_json.main_class);
 
     let mut cmd = Command::new(&java.path);
-    cmd.args(&jvm_extra);
-    cmd.args(&args);
+    cmd.args(&memory_args);
+    cmd.args(&jvm_args);
     cmd.arg(&version_json.main_class);
+    cmd.args(&game_args);
     cmd.current_dir(&minecraft_dir);
     cmd.stdout(std::process::Stdio::piped());
     cmd.stderr(std::process::Stdio::piped());

--- a/src-tauri/src/minecraft/launch.rs
+++ b/src-tauri/src/minecraft/launch.rs
@@ -1,5 +1,6 @@
-use std::collections::HashMap;
+use std::collections::{HashMap, VecDeque};
 use std::path::{Path, PathBuf};
+use std::sync::Arc;
 
 use serde::Serialize;
 use tauri::{AppHandle, Emitter};
@@ -33,6 +34,7 @@ struct GameLog {
 struct GameExit {
     instance_id: String,
     exit_code: Option<i32>,
+    crash_log: Option<String>,
 }
 
 pub async fn launch_instance(
@@ -218,10 +220,15 @@ pub async fn launch_instance(
         });
     }
 
+    const STDERR_TAIL_SIZE: usize = 50;
+    let stderr_tail: Arc<tokio::sync::Mutex<VecDeque<String>>> =
+        Arc::new(tokio::sync::Mutex::new(VecDeque::new()));
+
     let app_stderr = app.clone();
     let id_stderr = instance_id.clone();
-    if let Some(stderr) = stderr {
-        tokio::spawn(async move {
+    let stderr_tail_writer = stderr_tail.clone();
+    let stderr_handle = if let Some(stderr) = stderr {
+        Some(tokio::spawn(async move {
             let reader = BufReader::new(stderr);
             let mut lines = reader.lines();
             while let Ok(Some(line)) = lines.next_line().await {
@@ -229,13 +236,20 @@ pub async fn launch_instance(
                     "game-log",
                     GameLog {
                         instance_id: id_stderr.clone(),
-                        line,
+                        line: line.clone(),
                         stream: "stderr".into(),
                     },
                 );
+                let mut tail = stderr_tail_writer.lock().await;
+                tail.push_back(line);
+                if tail.len() > STDERR_TAIL_SIZE {
+                    tail.pop_front();
+                }
             }
-        });
-    }
+        }))
+    } else {
+        None
+    };
 
     // 12. Wait for exit in background
     let app_exit = app.clone();
@@ -244,11 +258,30 @@ pub async fn launch_instance(
         let status = child.wait().await;
         let exit_code = status.ok().and_then(|s| s.code());
         eprintln!("[launch] Minecraft exited with code: {exit_code:?}");
+
+        // Wait for stderr reader to finish so we have all lines
+        if let Some(handle) = stderr_handle {
+            let _ = handle.await;
+        }
+
+        // Include last stderr lines if the game crashed
+        let crash_log = if exit_code.is_some() && exit_code != Some(0) {
+            let tail = stderr_tail.lock().await;
+            if tail.is_empty() {
+                None
+            } else {
+                Some(tail.iter().cloned().collect::<Vec<_>>().join("\n"))
+            }
+        } else {
+            None
+        };
+
         let _ = app_exit.emit(
             "game-exit",
             GameExit {
                 instance_id: id_exit,
                 exit_code,
+                crash_log,
             },
         );
     });

--- a/src-tauri/src/minecraft/mod.rs
+++ b/src-tauri/src/minecraft/mod.rs
@@ -1,1 +1,6 @@
+pub mod adoptium;
+pub mod fabric;
+pub mod install;
 pub mod java;
+pub mod launch;
+pub mod version;

--- a/src-tauri/src/minecraft/version.rs
+++ b/src-tauri/src/minecraft/version.rs
@@ -206,12 +206,18 @@ pub async fn load_version_json(path: &Path) -> Result<VersionJson, LanternError>
     Ok(serde_json::from_str(&data)?)
 }
 
-/// Extract the Maven group:artifact key (without version) from a coordinate.
-/// e.g. "org.ow2.asm:asm:9.9" -> "org.ow2.asm:asm"
-fn maven_group_artifact(name: &str) -> &str {
-    match name.match_indices(':').nth(1) {
-        Some((idx, _)) => &name[..idx],
-        None => name,
+/// Build a deduplication key from a Maven coordinate, stripping only the version.
+/// 3-part "group:artifact:version"            -> "group:artifact"
+/// 4-part "group:artifact:version:classifier"  -> "group:artifact:classifier"
+/// This keeps native JARs (e.g. lwjgl:natives-macos-arm64) distinct from base JARs.
+fn maven_dedup_key(name: &str) -> String {
+    let parts: Vec<&str> = name.split(':').collect();
+    if parts.len() >= 4 {
+        format!("{}:{}:{}", parts[0], parts[1], parts[3])
+    } else if parts.len() >= 2 {
+        format!("{}:{}", parts[0], parts[1])
+    } else {
+        name.to_string()
     }
 }
 
@@ -229,14 +235,14 @@ pub fn merge_version_json(child: VersionJson, parent: VersionJson) -> VersionJso
 
     // Add child libs first (they win on conflicts)
     for lib in child.libraries {
-        let key = maven_group_artifact(&lib.name).to_string();
+        let key = maven_dedup_key(&lib.name);
         seen.insert(key);
         libs.push(lib);
     }
 
     // Add parent libs only if not shadowed by child
     for lib in merged.libraries {
-        let key = maven_group_artifact(&lib.name).to_string();
+        let key = maven_dedup_key(&lib.name);
         if !seen.contains(&key) {
             seen.insert(key);
             libs.push(lib);

--- a/src-tauri/src/minecraft/version.rs
+++ b/src-tauri/src/minecraft/version.rs
@@ -105,6 +105,9 @@ pub struct LibraryArtifact {
 pub struct Rule {
     pub action: String,
     pub os: Option<OsRule>,
+    /// Feature conditions (e.g. is_demo_user, has_custom_resolution).
+    /// Rules with features only match if all specified features are active.
+    pub features: Option<HashMap<String, bool>>,
 }
 
 #[derive(Debug, Clone, Deserialize)]
@@ -239,18 +242,29 @@ pub fn current_os_name() -> &'static str {
     }
 }
 
-/// Check if a library should be included based on its rules and the current OS.
+/// Check if a library/argument should be included based on its rules.
+/// Rules with `features` conditions are rejected (we don't enable
+/// is_demo_user, has_custom_resolution, quickPlay, etc.).
 fn library_allowed(rules: &[Rule]) -> bool {
     let os = current_os_name();
     let mut allowed = false;
 
     for rule in rules {
-        let matches = match &rule.os {
+        // Feature-gated rules: only match if all required features are false
+        // (i.e. we never enable demo mode, custom resolution, quickPlay, etc.)
+        if let Some(features) = &rule.features {
+            if features.values().any(|&v| v) {
+                // Rule requires a feature to be true, but we don't enable any
+                continue;
+            }
+        }
+
+        let os_matches = match &rule.os {
             Some(os_rule) => os_rule.name.as_deref().map_or(true, |name| name == os),
             None => true,
         };
 
-        if matches {
+        if os_matches {
             allowed = rule.action == "allow";
         }
     }

--- a/src-tauri/src/minecraft/version.rs
+++ b/src-tauri/src/minecraft/version.rs
@@ -206,16 +206,43 @@ pub async fn load_version_json(path: &Path) -> Result<VersionJson, LanternError>
     Ok(serde_json::from_str(&data)?)
 }
 
+/// Extract the Maven group:artifact key (without version) from a coordinate.
+/// e.g. "org.ow2.asm:asm:9.9" -> "org.ow2.asm:asm"
+fn maven_group_artifact(name: &str) -> &str {
+    match name.match_indices(':').nth(1) {
+        Some((idx, _)) => &name[..idx],
+        None => name,
+    }
+}
+
 /// Merge a child version JSON (e.g. Fabric) with its parent (vanilla).
 /// The child overrides mainClass and adds its libraries.
+/// Libraries are deduplicated by group:artifact — child versions win.
 pub fn merge_version_json(child: VersionJson, parent: VersionJson) -> VersionJson {
     let mut merged = parent;
     merged.id = child.id;
     merged.main_class = child.main_class;
 
-    // Prepend child libraries (they take priority)
-    let mut libs = child.libraries;
-    libs.extend(merged.libraries);
+    // Deduplicate libraries: child versions take priority over parent
+    let mut seen = std::collections::HashSet::new();
+    let mut libs = Vec::new();
+
+    // Add child libs first (they win on conflicts)
+    for lib in child.libraries {
+        let key = maven_group_artifact(&lib.name).to_string();
+        seen.insert(key);
+        libs.push(lib);
+    }
+
+    // Add parent libs only if not shadowed by child
+    for lib in merged.libraries {
+        let key = maven_group_artifact(&lib.name).to_string();
+        if !seen.contains(&key) {
+            seen.insert(key);
+            libs.push(lib);
+        }
+    }
+
     merged.libraries = libs;
 
     // Merge arguments

--- a/src-tauri/src/minecraft/version.rs
+++ b/src-tauri/src/minecraft/version.rs
@@ -299,24 +299,37 @@ fn argument_allowed(rules: &[Rule]) -> bool {
     library_allowed(rules) // same logic
 }
 
-/// Resolve the full list of JVM + game arguments from a version JSON.
-pub fn resolve_arguments(
+/// Resolve JVM arguments from a version JSON.
+pub fn resolve_jvm_arguments(
     version: &VersionJson,
     subs: &HashMap<&str, String>,
 ) -> Vec<String> {
     let mut args = Vec::new();
 
     if let Some(ref arguments) = version.arguments {
-        // Modern format (1.13+)
         for val in &arguments.jvm {
             collect_argument_value(val, subs, &mut args);
         }
+    } else {
+        // Legacy format (pre-1.13): use default JVM args
+        args.extend(default_jvm_args(subs));
+    }
+
+    args
+}
+
+/// Resolve game arguments from a version JSON.
+pub fn resolve_game_arguments(
+    version: &VersionJson,
+    subs: &HashMap<&str, String>,
+) -> Vec<String> {
+    let mut args = Vec::new();
+
+    if let Some(ref arguments) = version.arguments {
         for val in &arguments.game {
             collect_argument_value(val, subs, &mut args);
         }
     } else if let Some(ref mc_args) = version.minecraft_arguments {
-        // Legacy format (pre-1.13): default JVM args + split game args
-        args.extend(default_jvm_args(subs));
         for token in mc_args.split_whitespace() {
             args.push(substitute(token, subs));
         }

--- a/src-tauri/src/minecraft/version.rs
+++ b/src-tauri/src/minecraft/version.rs
@@ -1,0 +1,394 @@
+use std::collections::HashMap;
+use std::path::Path;
+
+use serde::Deserialize;
+
+use crate::error::LanternError;
+
+const VERSION_MANIFEST_URL: &str =
+    "https://piston-meta.mojang.com/mc/game/version_manifest_v2.json";
+
+// -- Version manifest (top-level index of all MC versions) --
+
+#[derive(Debug, Deserialize)]
+pub struct VersionManifest {
+    pub latest: LatestVersions,
+    pub versions: Vec<ManifestEntry>,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct LatestVersions {
+    pub release: String,
+    pub snapshot: String,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct ManifestEntry {
+    pub id: String,
+    #[serde(rename = "type")]
+    pub version_type: String,
+    pub url: String,
+    pub sha1: String,
+}
+
+// -- Individual version JSON --
+
+#[derive(Debug, Clone, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct VersionJson {
+    pub id: String,
+    pub main_class: String,
+    #[serde(default)]
+    pub asset_index: Option<AssetIndexRef>,
+    #[serde(default)]
+    pub downloads: Option<VersionDownloads>,
+    #[serde(default)]
+    pub libraries: Vec<Library>,
+    #[serde(default)]
+    pub arguments: Option<Arguments>,
+    #[serde(default)]
+    pub minecraft_arguments: Option<String>,
+    #[serde(default)]
+    pub inherits_from: Option<String>,
+    #[serde(rename = "type", default)]
+    pub version_type: String,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct VersionDownloads {
+    pub client: DownloadEntry,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct DownloadEntry {
+    pub sha1: String,
+    pub size: u64,
+    pub url: String,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct AssetIndexRef {
+    pub id: String,
+    pub sha1: String,
+    pub size: u64,
+    pub url: String,
+    pub total_size: u64,
+}
+
+// -- Libraries --
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct Library {
+    pub name: String,
+    pub downloads: Option<LibraryDownloads>,
+    pub rules: Option<Vec<Rule>>,
+    pub natives: Option<HashMap<String, String>>,
+    pub url: Option<String>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct LibraryDownloads {
+    pub artifact: Option<LibraryArtifact>,
+    pub classifiers: Option<HashMap<String, LibraryArtifact>>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct LibraryArtifact {
+    pub path: String,
+    pub sha1: String,
+    pub size: u64,
+    pub url: String,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct Rule {
+    pub action: String,
+    pub os: Option<OsRule>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct OsRule {
+    pub name: Option<String>,
+    pub arch: Option<String>,
+}
+
+// -- Arguments --
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct Arguments {
+    #[serde(default)]
+    pub game: Vec<ArgumentValue>,
+    #[serde(default)]
+    pub jvm: Vec<ArgumentValue>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+#[serde(untagged)]
+pub enum ArgumentValue {
+    Plain(String),
+    Conditional {
+        rules: Vec<Rule>,
+        value: SingleOrVec,
+    },
+}
+
+#[derive(Debug, Clone, Deserialize)]
+#[serde(untagged)]
+pub enum SingleOrVec {
+    Single(String),
+    Multiple(Vec<String>),
+}
+
+// -- Asset index --
+
+#[derive(Debug, Deserialize)]
+pub struct AssetIndex {
+    pub objects: HashMap<String, AssetObject>,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct AssetObject {
+    pub hash: String,
+    pub size: u64,
+}
+
+// -- Functions --
+
+pub async fn fetch_version_manifest(
+    client: &reqwest::Client,
+) -> Result<VersionManifest, LanternError> {
+    let manifest = client
+        .get(VERSION_MANIFEST_URL)
+        .send()
+        .await?
+        .error_for_status()?
+        .json::<VersionManifest>()
+        .await?;
+    Ok(manifest)
+}
+
+pub async fn fetch_version_json(
+    client: &reqwest::Client,
+    data_dir: &Path,
+    version_id: &str,
+    url: &str,
+) -> Result<VersionJson, LanternError> {
+    let version_dir = data_dir.join("versions").join(version_id);
+    let json_path = version_dir.join(format!("{version_id}.json"));
+
+    // Use cached version if it exists
+    if json_path.exists() {
+        let data = tokio::fs::read_to_string(&json_path).await?;
+        return Ok(serde_json::from_str(&data)?);
+    }
+
+    let json_text = client
+        .get(url)
+        .send()
+        .await?
+        .error_for_status()?
+        .text()
+        .await?;
+
+    tokio::fs::create_dir_all(&version_dir).await?;
+    tokio::fs::write(&json_path, &json_text).await?;
+
+    Ok(serde_json::from_str(&json_text)?)
+}
+
+/// Load a version JSON from a local path (e.g. Fabric profile JSON).
+pub async fn load_version_json(path: &Path) -> Result<VersionJson, LanternError> {
+    let data = tokio::fs::read_to_string(path).await?;
+    Ok(serde_json::from_str(&data)?)
+}
+
+/// Merge a child version JSON (e.g. Fabric) with its parent (vanilla).
+/// The child overrides mainClass and adds its libraries.
+pub fn merge_version_json(child: VersionJson, parent: VersionJson) -> VersionJson {
+    let mut merged = parent;
+    merged.id = child.id;
+    merged.main_class = child.main_class;
+
+    // Prepend child libraries (they take priority)
+    let mut libs = child.libraries;
+    libs.extend(merged.libraries);
+    merged.libraries = libs;
+
+    // Merge arguments
+    if let Some(child_args) = child.arguments {
+        if let Some(ref mut parent_args) = merged.arguments {
+            parent_args.game.extend(child_args.game);
+            parent_args.jvm.extend(child_args.jvm);
+        } else {
+            merged.arguments = Some(child_args);
+        }
+    }
+
+    merged
+}
+
+/// Returns the current OS name in Mojang's format.
+pub fn current_os_name() -> &'static str {
+    if cfg!(target_os = "macos") {
+        "osx"
+    } else if cfg!(target_os = "windows") {
+        "windows"
+    } else {
+        "linux"
+    }
+}
+
+/// Check if a library should be included based on its rules and the current OS.
+fn library_allowed(rules: &[Rule]) -> bool {
+    let os = current_os_name();
+    let mut allowed = false;
+
+    for rule in rules {
+        let matches = match &rule.os {
+            Some(os_rule) => os_rule.name.as_deref().map_or(true, |name| name == os),
+            None => true,
+        };
+
+        if matches {
+            allowed = rule.action == "allow";
+        }
+    }
+
+    allowed
+}
+
+/// Filter libraries to only those allowed on the current OS.
+pub fn filter_libraries(libraries: &[Library]) -> Vec<&Library> {
+    libraries
+        .iter()
+        .filter(|lib| match &lib.rules {
+            Some(rules) => library_allowed(rules),
+            None => true, // no rules = always included
+        })
+        .collect()
+}
+
+/// Get the artifact path for a library from its Maven coordinate.
+/// e.g. "org.lwjgl:lwjgl:3.3.1" -> "org/lwjgl/lwjgl/3.3.1/lwjgl-3.3.1.jar"
+pub fn maven_to_path(name: &str) -> Option<String> {
+    let parts: Vec<&str> = name.split(':').collect();
+    if parts.len() < 3 {
+        return None;
+    }
+    let group = parts[0].replace('.', "/");
+    let artifact = parts[1];
+    let version = parts[2];
+    Some(format!(
+        "{group}/{artifact}/{version}/{artifact}-{version}.jar"
+    ))
+}
+
+/// Resolve argument template variables.
+/// Replaces ${key} with values from the substitutions map.
+fn substitute(template: &str, subs: &HashMap<&str, String>) -> String {
+    let mut result = template.to_string();
+    for (key, value) in subs {
+        result = result.replace(&format!("${{{key}}}"), value);
+    }
+    result
+}
+
+/// Check if an argument's rules allow it on the current OS.
+fn argument_allowed(rules: &[Rule]) -> bool {
+    library_allowed(rules) // same logic
+}
+
+/// Resolve the full list of JVM + game arguments from a version JSON.
+pub fn resolve_arguments(
+    version: &VersionJson,
+    subs: &HashMap<&str, String>,
+) -> Vec<String> {
+    let mut args = Vec::new();
+
+    if let Some(ref arguments) = version.arguments {
+        // Modern format (1.13+)
+        for val in &arguments.jvm {
+            collect_argument_value(val, subs, &mut args);
+        }
+        for val in &arguments.game {
+            collect_argument_value(val, subs, &mut args);
+        }
+    } else if let Some(ref mc_args) = version.minecraft_arguments {
+        // Legacy format (pre-1.13): default JVM args + split game args
+        args.extend(default_jvm_args(subs));
+        for token in mc_args.split_whitespace() {
+            args.push(substitute(token, subs));
+        }
+    }
+
+    args
+}
+
+fn collect_argument_value(
+    val: &ArgumentValue,
+    subs: &HashMap<&str, String>,
+    out: &mut Vec<String>,
+) {
+    match val {
+        ArgumentValue::Plain(s) => {
+            out.push(substitute(s, subs));
+        }
+        ArgumentValue::Conditional { rules, value } => {
+            if argument_allowed(rules) {
+                match value {
+                    SingleOrVec::Single(s) => out.push(substitute(s, subs)),
+                    SingleOrVec::Multiple(v) => {
+                        for s in v {
+                            out.push(substitute(s, subs));
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+/// Default JVM arguments for legacy version JSONs (pre-1.13).
+fn default_jvm_args(subs: &HashMap<&str, String>) -> Vec<String> {
+    let templates = [
+        "-Djava.library.path=${natives_directory}",
+        "-Dminecraft.launcher.brand=${launcher_name}",
+        "-Dminecraft.launcher.version=${launcher_version}",
+        "-cp",
+        "${classpath}",
+    ];
+    templates
+        .iter()
+        .map(|t| substitute(t, subs))
+        .collect()
+}
+
+// -- Fetch helpers for assets --
+
+pub async fn fetch_asset_index(
+    client: &reqwest::Client,
+    data_dir: &Path,
+    asset_ref: &AssetIndexRef,
+) -> Result<AssetIndex, LanternError> {
+    let index_dir = data_dir.join("assets").join("indexes");
+    let index_path = index_dir.join(format!("{}.json", asset_ref.id));
+
+    if index_path.exists() {
+        let data = tokio::fs::read_to_string(&index_path).await?;
+        return Ok(serde_json::from_str(&data)?);
+    }
+
+    let text = client
+        .get(&asset_ref.url)
+        .send()
+        .await?
+        .error_for_status()?
+        .text()
+        .await?;
+
+    tokio::fs::create_dir_all(&index_dir).await?;
+    tokio::fs::write(&index_path, &text).await?;
+
+    Ok(serde_json::from_str(&text)?)
+}

--- a/src-tauri/src/settings.rs
+++ b/src-tauri/src/settings.rs
@@ -1,0 +1,50 @@
+use std::path::{Path, PathBuf};
+
+use serde::{Deserialize, Serialize};
+
+const SETTINGS_FILE: &str = "settings.json";
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Settings {
+    /// Override for the game data directory. When set, all game data
+    /// (instances, libraries, assets, etc.) is stored here instead of
+    /// the platform default.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub data_dir: Option<String>,
+}
+
+impl Default for Settings {
+    fn default() -> Self {
+        Self { data_dir: None }
+    }
+}
+
+impl Settings {
+    /// Load settings from the config directory. Returns defaults if the
+    /// file doesn't exist or can't be parsed.
+    pub fn load(config_dir: &Path) -> Self {
+        let path = config_dir.join(SETTINGS_FILE);
+        match std::fs::read_to_string(&path) {
+            Ok(data) => serde_json::from_str(&data).unwrap_or_default(),
+            Err(_) => Self::default(),
+        }
+    }
+
+    /// Save settings to the config directory.
+    pub fn save(&self, config_dir: &Path) -> Result<(), std::io::Error> {
+        std::fs::create_dir_all(config_dir)?;
+        let data = serde_json::to_string_pretty(self)
+            .map_err(|e| std::io::Error::new(std::io::ErrorKind::Other, e))?;
+        std::fs::write(config_dir.join(SETTINGS_FILE), data)
+    }
+
+    /// Resolve the effective data directory: the override if set,
+    /// otherwise the provided default.
+    pub fn resolve_data_dir(&self, default: &Path) -> PathBuf {
+        self.data_dir
+            .as_ref()
+            .filter(|s| !s.is_empty())
+            .map(PathBuf::from)
+            .unwrap_or_else(|| default.to_path_buf())
+    }
+}

--- a/src-tauri/src/state.rs
+++ b/src-tauri/src/state.rs
@@ -30,6 +30,14 @@ impl AppState {
         std::fs::create_dir_all(&data_dir).expect("Failed to create data directory");
         std::fs::create_dir_all(data_dir.join("instances"))
             .expect("Failed to create instances dir");
+        std::fs::create_dir_all(data_dir.join("versions"))
+            .expect("Failed to create versions dir");
+        std::fs::create_dir_all(data_dir.join("assets"))
+            .expect("Failed to create assets dir");
+        std::fs::create_dir_all(data_dir.join("libraries"))
+            .expect("Failed to create libraries dir");
+        std::fs::create_dir_all(data_dir.join("java"))
+            .expect("Failed to create java dir");
 
         Self {
             http_client: reqwest::Client::builder()

--- a/src-tauri/src/state.rs
+++ b/src-tauri/src/state.rs
@@ -23,10 +23,12 @@ pub struct AppState {
     pub instances: Mutex<InstanceManager>,
     pub auth: Mutex<AuthState>,
     pub data_dir: PathBuf,
+    pub config_dir: PathBuf,
+    pub default_data_dir: PathBuf,
 }
 
 impl AppState {
-    pub fn new(data_dir: PathBuf) -> Self {
+    pub fn new(data_dir: PathBuf, config_dir: PathBuf, default_data_dir: PathBuf) -> Self {
         std::fs::create_dir_all(&data_dir).expect("Failed to create data directory");
         std::fs::create_dir_all(data_dir.join("instances"))
             .expect("Failed to create instances dir");
@@ -47,6 +49,8 @@ impl AppState {
             instances: Mutex::new(InstanceManager::new(data_dir.join("instances"))),
             auth: Mutex::new(AuthState::new()),
             data_dir,
+            config_dir,
+            default_data_dir,
         }
     }
 }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -6,6 +6,8 @@ import Browse from "@/pages/Browse";
 import Settings from "@/pages/Settings";
 import Login from "@/pages/Login";
 import { useAuth } from "@/hooks/useAuth";
+import { useGameStatus } from "@/hooks/useGameStatus";
+import { launchInstance } from "@/api/launch";
 import type { Page } from "@/types";
 
 export default function App() {
@@ -18,8 +20,11 @@ export default function App() {
     );
     const [showOfflinePopup, setShowOfflinePopup] = useState(false);
     const [pendingLaunchId, setPendingLaunchId] = useState<string | null>(null);
+    const [launchError, setLaunchError] = useState<string | null>(null);
+    const [refreshKey, setRefreshKey] = useState(0);
 
     const { profile, setProfile, handleLogout } = useAuth();
+    const runningInstance = useGameStatus();
 
     function handleToggleOnline() {
         setIsOnline((prev) => {
@@ -29,14 +34,27 @@ export default function App() {
         });
     }
 
+    async function doLaunch(instanceId: string, username?: string) {
+        setLaunchError(null);
+        try {
+            await launchInstance(instanceId, isOnline, username ?? undefined);
+        } catch (e: unknown) {
+            const msg = e instanceof Error ? e.message : String(e);
+            console.error("Launch failed:", msg);
+            setLaunchError(msg);
+        }
+    }
+
     function handlePlay(instanceId: string) {
+        if (runningInstance) return; // already running
+
         if (!isOnline && !offlineUsername) {
             setPendingLaunchId(instanceId);
             setShowOfflinePopup(true);
             return;
         }
-        // TODO: invoke Tauri launch command
-        console.log("Launch:", instanceId, isOnline ? "online" : "offline");
+
+        doLaunch(instanceId, isOnline ? undefined : offlineUsername ?? undefined);
     }
 
     function handleOfflineSubmit(username: string) {
@@ -44,7 +62,7 @@ export default function App() {
         setOfflineUsername(username);
         setShowOfflinePopup(false);
         if (pendingLaunchId) {
-            console.log("Launch:", pendingLaunchId, "offline as", username);
+            doLaunch(pendingLaunchId, username);
             setPendingLaunchId(null);
         }
     }
@@ -67,8 +85,20 @@ export default function App() {
                 onLogout={handleLogoutAndNavigate}
             />
             <main className="main-content">
-                {page.kind === "home" && <Home onPlay={handlePlay} />}
-                {page.kind === "browse" && <Browse navigate={setPage} />}
+                {page.kind === "home" && (
+                    <Home
+                        onPlay={handlePlay}
+                        runningInstance={runningInstance}
+                        launchError={launchError}
+                        refreshKey={refreshKey}
+                    />
+                )}
+                {page.kind === "browse" && (
+                    <Browse
+                        navigate={setPage}
+                        onInstalled={() => setRefreshKey((k) => k + 1)}
+                    />
+                )}
                 {page.kind === "settings" && <Settings navigate={setPage} />}
                 {page.kind === "login" && (
                     <Login

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -24,7 +24,7 @@ export default function App() {
     const [refreshKey, setRefreshKey] = useState(0);
 
     const { profile, setProfile, handleLogout } = useAuth();
-    const runningInstance = useGameStatus();
+    const { running: runningInstance, crashLog } = useGameStatus();
 
     function handleToggleOnline() {
         setIsOnline((prev) => {
@@ -89,7 +89,7 @@ export default function App() {
                     <Home
                         onPlay={handlePlay}
                         runningInstance={runningInstance}
-                        launchError={launchError}
+                        launchError={launchError ?? crashLog}
                         refreshKey={refreshKey}
                     />
                 )}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -22,6 +22,7 @@ export default function App() {
     const [pendingLaunchId, setPendingLaunchId] = useState<string | null>(null);
     const [launchError, setLaunchError] = useState<string | null>(null);
     const [refreshKey, setRefreshKey] = useState(0);
+    const [preparingInstance, setPreparingInstance] = useState<string | null>(null);
 
     const { profile, setProfile, handleLogout } = useAuth();
     const { running: runningInstance, crashLog } = useGameStatus();
@@ -36,17 +37,20 @@ export default function App() {
 
     async function doLaunch(instanceId: string, username?: string) {
         setLaunchError(null);
+        setPreparingInstance(instanceId);
         try {
             await launchInstance(instanceId, isOnline, username ?? undefined);
         } catch (e: unknown) {
             const msg = e instanceof Error ? e.message : String(e);
             console.error("Launch failed:", msg);
             setLaunchError(msg);
+        } finally {
+            setPreparingInstance(null);
         }
     }
 
     function handlePlay(instanceId: string) {
-        if (runningInstance) return; // already running
+        if (runningInstance || preparingInstance) return;
 
         if (!isOnline && !offlineUsername) {
             setPendingLaunchId(instanceId);
@@ -89,6 +93,7 @@ export default function App() {
                     <Home
                         onPlay={handlePlay}
                         runningInstance={runningInstance}
+                        preparingInstance={preparingInstance}
                         launchError={launchError ?? crashLog}
                         refreshKey={refreshKey}
                     />

--- a/src/api/install.ts
+++ b/src/api/install.ts
@@ -1,0 +1,6 @@
+import { invoke } from "@tauri-apps/api/core";
+import type { Instance } from "../types";
+
+export async function installModpack(projectId: string, versionId: string): Promise<Instance> {
+    return invoke("install_modpack", { projectId, versionId });
+}

--- a/src/api/launch.ts
+++ b/src/api/launch.ts
@@ -1,0 +1,9 @@
+import { invoke } from "@tauri-apps/api/core";
+
+export async function launchInstance(
+    instanceId: string,
+    online: boolean,
+    username?: string,
+): Promise<void> {
+    return invoke("launch_instance", { instanceId, online, username });
+}

--- a/src/api/settings.ts
+++ b/src/api/settings.ts
@@ -1,0 +1,15 @@
+import { invoke } from "@tauri-apps/api/core";
+
+export interface SettingsInfo {
+    data_dir: string;
+    default_data_dir: string;
+    data_dir_override: string | null;
+}
+
+export async function getSettings(): Promise<SettingsInfo> {
+    return invoke("get_settings");
+}
+
+export async function setDataDir(path: string | null): Promise<void> {
+    return invoke("set_data_dir", { path });
+}

--- a/src/components/ModpackRow.module.css
+++ b/src/components/ModpackRow.module.css
@@ -136,6 +136,21 @@
     box-shadow: none;
 }
 
+.preparing {
+    color: var(--accent);
+    font-weight: 500;
+}
+
+.playBtnPreparing {
+    background: var(--accent);
+    opacity: 0.8;
+}
+
+.playBtnPreparing:hover {
+    background: var(--accent);
+    box-shadow: none;
+}
+
 .running {
     color: var(--online);
     font-weight: 500;

--- a/src/components/ModpackRow.module.css
+++ b/src/components/ModpackRow.module.css
@@ -126,3 +126,17 @@
     color: var(--accent);
     background: var(--accent-soft);
 }
+
+.playBtnRunning {
+    background: var(--online);
+}
+
+.playBtnRunning:hover {
+    background: var(--online);
+    box-shadow: none;
+}
+
+.running {
+    color: var(--online);
+    font-weight: 500;
+}

--- a/src/components/ModpackRow.tsx
+++ b/src/components/ModpackRow.tsx
@@ -1,4 +1,3 @@
-import { useState } from "react";
 import type { Instance } from "../types";
 import { PlayIcon, RefreshIcon, SettingsIcon, SpinnerIcon, PackageIcon } from "./Icons";
 import styles from "./ModpackRow.module.css";
@@ -10,6 +9,7 @@ interface ModpackRowProps {
     onSettings?: (id: string) => void;
     updateAvailable?: boolean;
     index?: number;
+    isRunning?: boolean;
 }
 
 const loaderLabel: Record<string, string> = {
@@ -27,14 +27,11 @@ export default function ModpackRow({
     onSettings,
     updateAvailable = false,
     index = 0,
+    isRunning = false,
 }: ModpackRowProps) {
-    const [launching, setLaunching] = useState(false);
-
     function handlePlay(e: React.MouseEvent) {
         e.stopPropagation();
-        setLaunching(true);
-        onPlay(instance.id);
-        setTimeout(() => setLaunching(false), 1500);
+        if (!isRunning) onPlay(instance.id);
     }
 
     const versionText = instance.modpack?.version_name || instance.minecraft_version;
@@ -62,17 +59,23 @@ export default function ModpackRow({
                             <span>{authorText}</span>
                         </>
                     )}
+                    {isRunning && (
+                        <>
+                            <span className={styles.dot}>&middot;</span>
+                            <span className={styles.running}>Running</span>
+                        </>
+                    )}
                 </div>
             </div>
 
             <div className={styles.actions}>
                 <button
-                    className={styles.playBtn}
+                    className={`${styles.playBtn} ${isRunning ? styles.playBtnRunning : ""}`}
                     onClick={handlePlay}
-                    disabled={launching}
-                    title="Play"
+                    disabled={isRunning}
+                    title={isRunning ? "Running" : "Play"}
                 >
-                    {launching ? <SpinnerIcon size={16} /> : <PlayIcon size={16} />}
+                    {isRunning ? <SpinnerIcon size={16} /> : <PlayIcon size={16} />}
                 </button>
                 <button
                     className={`${styles.actionBtn} ${updateAvailable ? styles.updateHighlight : ""}`}

--- a/src/components/ModpackRow.tsx
+++ b/src/components/ModpackRow.tsx
@@ -10,6 +10,7 @@ interface ModpackRowProps {
     updateAvailable?: boolean;
     index?: number;
     isRunning?: boolean;
+    isPreparing?: boolean;
 }
 
 const loaderLabel: Record<string, string> = {
@@ -28,10 +29,13 @@ export default function ModpackRow({
     updateAvailable = false,
     index = 0,
     isRunning = false,
+    isPreparing = false,
 }: ModpackRowProps) {
+    const busy = isRunning || isPreparing;
+
     function handlePlay(e: React.MouseEvent) {
         e.stopPropagation();
-        if (!isRunning) onPlay(instance.id);
+        if (!busy) onPlay(instance.id);
     }
 
     const versionText = instance.modpack?.version_name || instance.minecraft_version;
@@ -59,6 +63,12 @@ export default function ModpackRow({
                             <span>{authorText}</span>
                         </>
                     )}
+                    {isPreparing && (
+                        <>
+                            <span className={styles.dot}>&middot;</span>
+                            <span className={styles.preparing}>Preparing...</span>
+                        </>
+                    )}
                     {isRunning && (
                         <>
                             <span className={styles.dot}>&middot;</span>
@@ -70,12 +80,12 @@ export default function ModpackRow({
 
             <div className={styles.actions}>
                 <button
-                    className={`${styles.playBtn} ${isRunning ? styles.playBtnRunning : ""}`}
+                    className={`${styles.playBtn} ${isRunning ? styles.playBtnRunning : ""} ${isPreparing ? styles.playBtnPreparing : ""}`}
                     onClick={handlePlay}
-                    disabled={isRunning}
-                    title={isRunning ? "Running" : "Play"}
+                    disabled={busy}
+                    title={isRunning ? "Running" : isPreparing ? "Preparing..." : "Play"}
                 >
-                    {isRunning ? <SpinnerIcon size={16} /> : <PlayIcon size={16} />}
+                    {busy ? <SpinnerIcon size={16} /> : <PlayIcon size={16} />}
                 </button>
                 <button
                     className={`${styles.actionBtn} ${updateAvailable ? styles.updateHighlight : ""}`}

--- a/src/hooks/useGameStatus.ts
+++ b/src/hooks/useGameStatus.ts
@@ -1,0 +1,33 @@
+import { useEffect, useRef, useState } from "react";
+import { listen } from "@tauri-apps/api/event";
+import type { GameExitEvent } from "../types";
+
+export function useGameStatus() {
+    const [running, setRunning] = useState<string | null>(null);
+    const unlistenRefs = useRef<(() => void)[]>([]);
+
+    useEffect(() => {
+        let cancelled = false;
+
+        listen<{ instance_id: string }>("game-started", (event) => {
+            if (!cancelled) setRunning(event.payload.instance_id);
+        }).then((unlisten) => {
+            if (cancelled) unlisten();
+            else unlistenRefs.current.push(unlisten);
+        });
+
+        listen<GameExitEvent>("game-exit", () => {
+            if (!cancelled) setRunning(null);
+        }).then((unlisten) => {
+            if (cancelled) unlisten();
+            else unlistenRefs.current.push(unlisten);
+        });
+
+        return () => {
+            cancelled = true;
+            unlistenRefs.current.forEach((fn) => fn());
+        };
+    }, []);
+
+    return running;
+}

--- a/src/hooks/useGameStatus.ts
+++ b/src/hooks/useGameStatus.ts
@@ -2,22 +2,38 @@ import { useEffect, useRef, useState } from "react";
 import { listen } from "@tauri-apps/api/event";
 import type { GameExitEvent } from "../types";
 
-export function useGameStatus() {
+interface GameStatus {
+    running: string | null;
+    crashLog: string | null;
+}
+
+export function useGameStatus(): GameStatus {
     const [running, setRunning] = useState<string | null>(null);
+    const [crashLog, setCrashLog] = useState<string | null>(null);
     const unlistenRefs = useRef<(() => void)[]>([]);
 
     useEffect(() => {
         let cancelled = false;
 
         listen<{ instance_id: string }>("game-started", (event) => {
-            if (!cancelled) setRunning(event.payload.instance_id);
+            if (!cancelled) {
+                setRunning(event.payload.instance_id);
+                setCrashLog(null);
+            }
         }).then((unlisten) => {
             if (cancelled) unlisten();
             else unlistenRefs.current.push(unlisten);
         });
 
-        listen<GameExitEvent>("game-exit", () => {
-            if (!cancelled) setRunning(null);
+        listen<GameExitEvent>("game-exit", (event) => {
+            if (!cancelled) {
+                setRunning(null);
+                const { exit_code, crash_log } = event.payload;
+                if (exit_code !== null && exit_code !== 0) {
+                    const header = `Game crashed with exit code ${exit_code}`;
+                    setCrashLog(crash_log ? `${header}\n${crash_log}` : header);
+                }
+            }
         }).then((unlisten) => {
             if (cancelled) unlisten();
             else unlistenRefs.current.push(unlisten);
@@ -29,5 +45,5 @@ export function useGameStatus() {
         };
     }, []);
 
-    return running;
+    return { running, crashLog };
 }

--- a/src/hooks/useInstallProgress.ts
+++ b/src/hooks/useInstallProgress.ts
@@ -1,0 +1,33 @@
+import { useEffect, useRef, useState } from "react";
+import { listen } from "@tauri-apps/api/event";
+import type { InstallProgress } from "../types";
+
+export function useInstallProgress() {
+    const [progress, setProgress] = useState<Record<string, InstallProgress>>({});
+    const unlistenRef = useRef<(() => void) | null>(null);
+
+    useEffect(() => {
+        let cancelled = false;
+
+        listen<InstallProgress>("install-progress", (event) => {
+            if (cancelled) return;
+            setProgress((prev) => ({
+                ...prev,
+                [event.payload.project_id]: event.payload,
+            }));
+        }).then((unlisten) => {
+            if (cancelled) {
+                unlisten();
+            } else {
+                unlistenRef.current = unlisten;
+            }
+        });
+
+        return () => {
+            cancelled = true;
+            unlistenRef.current?.();
+        };
+    }, []);
+
+    return progress;
+}

--- a/src/pages/Browse.module.css
+++ b/src/pages/Browse.module.css
@@ -187,3 +187,21 @@
     color: var(--online);
     background: var(--online-soft);
 }
+
+.error {
+    border-color: #c45050;
+    color: #c45050;
+}
+
+.error:hover {
+    border-color: #c45050;
+    color: #c45050;
+    background: rgba(196, 80, 80, 0.1);
+}
+
+.progressText {
+    font-size: 11px;
+    color: var(--text-secondary);
+    white-space: nowrap;
+    flex-shrink: 0;
+}

--- a/src/pages/Browse.tsx
+++ b/src/pages/Browse.tsx
@@ -1,5 +1,7 @@
 import { useCallback, useRef, useState } from "react";
-import { searchModpacks } from "../api/modpacks";
+import { searchModpacks, listVersions } from "../api/modpacks";
+import { installModpack } from "../api/install";
+import { useInstallProgress } from "../hooks/useInstallProgress";
 import {
     SearchIcon,
     DownloadIcon,
@@ -13,15 +15,17 @@ import styles from "./Browse.module.css";
 
 interface BrowseProps {
     navigate: (page: Page) => void;
+    onInstalled?: () => void;
 }
 
-export default function Browse({ navigate }: BrowseProps) {
+export default function Browse({ navigate, onInstalled }: BrowseProps) {
     const [query, setQuery] = useState("");
     const [results, setResults] = useState<SearchHit[]>([]);
     const [loading, setLoading] = useState(false);
     const [searched, setSearched] = useState(false);
-    const [installing, setInstalling] = useState<Record<string, "loading" | "done">>({});
+    const [installing, setInstalling] = useState<Record<string, "loading" | "done" | "error">>({});
     const debounceRef = useRef<ReturnType<typeof setTimeout>>(null);
+    const progress = useInstallProgress();
 
     const doSearch = useCallback(async (q: string) => {
         if (q.trim().length === 0) return;
@@ -48,12 +52,35 @@ export default function Browse({ navigate }: BrowseProps) {
         debounceRef.current = setTimeout(() => doSearch(value), 300);
     }
 
-    function handleInstall(projectId: string) {
+    async function handleInstall(projectId: string) {
         setInstalling((prev) => ({ ...prev, [projectId]: "loading" }));
-        // TODO: invoke Tauri install command
-        setTimeout(() => {
+        try {
+            // Get the latest version for this modpack
+            const versions = await listVersions(projectId);
+            if (versions.length === 0) {
+                console.error("No versions available");
+                setInstalling((prev) => ({ ...prev, [projectId]: "error" }));
+                return;
+            }
+            const latest = versions[0];
+
+            await installModpack(projectId, latest.id);
             setInstalling((prev) => ({ ...prev, [projectId]: "done" }));
-        }, 2000);
+            onInstalled?.();
+        } catch (e) {
+            console.error("Install failed:", e);
+            setInstalling((prev) => ({ ...prev, [projectId]: "error" }));
+        }
+    }
+
+    function installStatus(projectId: string): string | null {
+        const p = progress[projectId];
+        if (!p) return null;
+        if (p.stage === "complete" || p.stage === "failed") return null;
+        if (p.stage === "installing_mods" && p.total > 0) {
+            return `${p.current}/${p.total}`;
+        }
+        return p.message;
     }
 
     return (
@@ -86,6 +113,7 @@ export default function Browse({ navigate }: BrowseProps) {
                     <div className={styles.resultsList}>
                         {results.map((hit, i) => {
                             const state = installing[hit.project_id];
+                            const statusText = installStatus(hit.project_id);
                             return (
                                 <div
                                     key={hit.project_id}
@@ -108,10 +136,13 @@ export default function Browse({ navigate }: BrowseProps) {
                                         <div className={styles.resultAuthor}>{hit.author}</div>
                                         <div className={styles.resultDesc}>{hit.description}</div>
                                     </div>
+                                    {statusText && state === "loading" && (
+                                        <span className={styles.progressText}>{statusText}</span>
+                                    )}
                                     <button
-                                        className={`${styles.installBtn} ${state === "done" ? styles.installed : ""}`}
+                                        className={`${styles.installBtn} ${state === "done" ? styles.installed : ""} ${state === "error" ? styles.error : ""}`}
                                         onClick={() => handleInstall(hit.project_id)}
-                                        disabled={!!state}
+                                        disabled={state === "loading" || state === "done"}
                                     >
                                         {state === "loading" ? (
                                             <SpinnerIcon size={14} />

--- a/src/pages/Home.module.css
+++ b/src/pages/Home.module.css
@@ -28,4 +28,8 @@
     border: 1px solid rgba(196, 80, 80, 0.3);
     color: #e07070;
     font-size: 12px;
+    white-space: pre-wrap;
+    max-height: 200px;
+    overflow-y: auto;
+    font-family: var(--font-mono, monospace);
 }

--- a/src/pages/Home.module.css
+++ b/src/pages/Home.module.css
@@ -19,3 +19,13 @@
     flex-direction: column;
     gap: 2px;
 }
+
+.errorBanner {
+    padding: 8px 14px;
+    margin-bottom: 8px;
+    border-radius: var(--radius);
+    background: rgba(196, 80, 80, 0.1);
+    border: 1px solid rgba(196, 80, 80, 0.3);
+    color: #e07070;
+    font-size: 12px;
+}

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -6,11 +6,18 @@ import styles from "./Home.module.css";
 interface HomeProps {
     onPlay: (id: string) => void;
     runningInstance: string | null;
+    preparingInstance: string | null;
     launchError: string | null;
     refreshKey: number;
 }
 
-export default function Home({ onPlay, runningInstance, launchError, refreshKey }: HomeProps) {
+export default function Home({
+    onPlay,
+    runningInstance,
+    preparingInstance,
+    launchError,
+    refreshKey,
+}: HomeProps) {
     const { instances, loading, refresh } = useInstances();
 
     useEffect(() => {
@@ -46,6 +53,7 @@ export default function Home({ onPlay, runningInstance, launchError, refreshKey 
                         onPlay={onPlay}
                         index={i}
                         isRunning={runningInstance === instance.id}
+                        isPreparing={preparingInstance === instance.id}
                     />
                 ))}
             </div>

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -5,14 +5,17 @@ import styles from "./Home.module.css";
 
 interface HomeProps {
     onPlay: (id: string) => void;
+    runningInstance: string | null;
+    launchError: string | null;
+    refreshKey: number;
 }
 
-export default function Home({ onPlay }: HomeProps) {
+export default function Home({ onPlay, runningInstance, launchError, refreshKey }: HomeProps) {
     const { instances, loading, refresh } = useInstances();
 
     useEffect(() => {
         refresh();
-    }, [refresh]);
+    }, [refresh, refreshKey]);
 
     if (loading) {
         return (
@@ -32,9 +35,18 @@ export default function Home({ onPlay }: HomeProps) {
 
     return (
         <div className={styles.home}>
+            {launchError && (
+                <div className={styles.errorBanner}>{launchError}</div>
+            )}
             <div className={styles.list}>
                 {instances.map((instance, i) => (
-                    <ModpackRow key={instance.id} instance={instance} onPlay={onPlay} index={i} />
+                    <ModpackRow
+                        key={instance.id}
+                        instance={instance}
+                        onPlay={onPlay}
+                        index={i}
+                        isRunning={runningInstance === instance.id}
+                    />
                 ))}
             </div>
         </div>

--- a/src/pages/Settings.module.css
+++ b/src/pages/Settings.module.css
@@ -148,30 +148,6 @@
     flex: 1;
 }
 
-.editRow {
-    display: flex;
-    align-items: center;
-    gap: 8px;
-    margin-top: 8px;
-}
-
-.pathInput {
-    flex: 1;
-    min-width: 0;
-    padding: 6px 10px;
-    background: var(--bg-input);
-    border: 1px solid var(--border);
-    border-radius: var(--radius-sm);
-    font-size: 11px;
-    font-family: inherit;
-    color: var(--text-primary);
-    outline: none;
-}
-
-.pathInput:focus {
-    border-color: var(--accent);
-}
-
 .restartNote {
     margin-top: 8px;
     padding: 6px 10px;

--- a/src/pages/Settings.module.css
+++ b/src/pages/Settings.module.css
@@ -87,6 +87,103 @@
     border-color: var(--accent);
 }
 
+/* Storage */
+.storageRow {
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+}
+
+.pathDisplay {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    margin-top: 8px;
+}
+
+.pathText {
+    flex: 1;
+    min-width: 0;
+    padding: 6px 10px;
+    background: var(--bg-input);
+    border: 1px solid var(--border);
+    border-radius: var(--radius-sm);
+    font-size: 11px;
+    color: var(--text-secondary);
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+
+.pathBtn {
+    padding: 5px 10px;
+    background: transparent;
+    border: 1px solid var(--border);
+    border-radius: var(--radius-sm);
+    color: var(--text-secondary);
+    font-size: 11px;
+    font-weight: 500;
+    font-family: inherit;
+    cursor: pointer;
+    transition: all var(--transition);
+    white-space: nowrap;
+}
+
+.pathBtn:hover {
+    border-color: var(--border-light);
+    color: var(--text-primary);
+    background: var(--bg-card-hover);
+}
+
+.overrideActions {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    margin-top: 6px;
+}
+
+.overrideNote {
+    font-size: 11px;
+    color: var(--text-muted);
+    flex: 1;
+}
+
+.editRow {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    margin-top: 8px;
+}
+
+.pathInput {
+    flex: 1;
+    min-width: 0;
+    padding: 6px 10px;
+    background: var(--bg-input);
+    border: 1px solid var(--border);
+    border-radius: var(--radius-sm);
+    font-size: 11px;
+    font-family: inherit;
+    color: var(--text-primary);
+    outline: none;
+}
+
+.pathInput:focus {
+    border-color: var(--accent);
+}
+
+.restartNote {
+    margin-top: 8px;
+    padding: 6px 10px;
+    border-radius: var(--radius-sm);
+    background: rgba(234, 179, 8, 0.1);
+    border: 1px solid rgba(234, 179, 8, 0.25);
+    color: #d4a017;
+    font-size: 11px;
+    font-weight: 500;
+}
+
+/* About */
 .aboutName {
     font-size: 14px;
     font-weight: 700;

--- a/src/pages/Settings.tsx
+++ b/src/pages/Settings.tsx
@@ -1,5 +1,7 @@
+import { useEffect, useState } from "react";
 import { openUrl } from "@tauri-apps/plugin-opener";
 import { ArrowLeftIcon, GithubIcon } from "../components/Icons";
+import { getSettings, setDataDir } from "../api/settings";
 import type { Page } from "../types";
 import styles from "./Settings.module.css";
 
@@ -8,6 +10,43 @@ interface SettingsProps {
 }
 
 export default function Settings({ navigate }: SettingsProps) {
+    const [dataDir, setDataDir_] = useState("");
+    const [defaultDataDir, setDefaultDataDir] = useState("");
+    const [override_, setOverride] = useState<string | null>(null);
+    const [draftOverride, setDraftOverride] = useState("");
+    const [editing, setEditing] = useState(false);
+    const [saved, setSaved] = useState(false);
+
+    useEffect(() => {
+        getSettings().then((s) => {
+            setDataDir_(s.data_dir);
+            setDefaultDataDir(s.default_data_dir);
+            setOverride(s.data_dir_override);
+            setDraftOverride(s.data_dir_override ?? "");
+        });
+    }, []);
+
+    async function handleSaveOverride() {
+        const value = draftOverride.trim() || null;
+        await setDataDir(value);
+        setOverride(value);
+        setEditing(false);
+        setSaved(true);
+    }
+
+    function handleCancelEdit() {
+        setDraftOverride(override_ ?? "");
+        setEditing(false);
+    }
+
+    async function handleReset() {
+        await setDataDir(null);
+        setOverride(null);
+        setDraftOverride("");
+        setEditing(false);
+        setSaved(true);
+    }
+
     return (
         <div className={styles.settings}>
             <button className={styles.back} onClick={() => navigate({ kind: "home" })}>
@@ -31,6 +70,75 @@ export default function Settings({ navigate }: SettingsProps) {
                             <option value="6144">6 GB</option>
                             <option value="8192">8 GB</option>
                         </select>
+                    </div>
+                </div>
+            </div>
+
+            <div className={styles.section}>
+                <div className={styles.sectionLabel}>Storage</div>
+                <div className={styles.card}>
+                    <div className={styles.storageRow}>
+                        <div className={styles.label}>Data Directory</div>
+                        <div className={styles.desc}>
+                            Where instances, libraries, and assets are stored
+                        </div>
+                        <div className={styles.pathDisplay}>
+                            <code className={styles.pathText}>{dataDir}</code>
+                            <button
+                                className={styles.pathBtn}
+                                onClick={() => openUrl(`file://${dataDir}`)}
+                                title="Open in file manager"
+                            >
+                                Open
+                            </button>
+                        </div>
+
+                        {!editing ? (
+                            <div className={styles.overrideActions}>
+                                {override_ && (
+                                    <div className={styles.overrideNote}>
+                                        Custom path set (default: {defaultDataDir})
+                                    </div>
+                                )}
+                                <button
+                                    className={styles.pathBtn}
+                                    onClick={() => setEditing(true)}
+                                >
+                                    {override_ ? "Change" : "Set custom path"}
+                                </button>
+                                {override_ && (
+                                    <button
+                                        className={styles.pathBtn}
+                                        onClick={handleReset}
+                                    >
+                                        Reset to default
+                                    </button>
+                                )}
+                            </div>
+                        ) : (
+                            <div className={styles.editRow}>
+                                <input
+                                    className={styles.pathInput}
+                                    type="text"
+                                    value={draftOverride}
+                                    onChange={(e) => setDraftOverride(e.target.value)}
+                                    placeholder={defaultDataDir}
+                                    autoFocus
+                                />
+                                <button className={styles.pathBtn} onClick={handleSaveOverride}>
+                                    Save
+                                </button>
+                                <button className={styles.pathBtn} onClick={handleCancelEdit}>
+                                    Cancel
+                                </button>
+                            </div>
+                        )}
+
+                        {saved && (
+                            <div className={styles.restartNote}>
+                                Restart Lantern for changes to take effect
+                            </div>
+                        )}
                     </div>
                 </div>
             </div>

--- a/src/pages/Settings.tsx
+++ b/src/pages/Settings.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useState } from "react";
 import { openUrl } from "@tauri-apps/plugin-opener";
+import { open as openDialog } from "@tauri-apps/plugin-dialog";
 import { ArrowLeftIcon, GithubIcon } from "../components/Icons";
 import { getSettings, setDataDir } from "../api/settings";
 import type { Page } from "../types";
@@ -13,8 +14,6 @@ export default function Settings({ navigate }: SettingsProps) {
     const [dataDir, setDataDir_] = useState("");
     const [defaultDataDir, setDefaultDataDir] = useState("");
     const [override_, setOverride] = useState<string | null>(null);
-    const [draftOverride, setDraftOverride] = useState("");
-    const [editing, setEditing] = useState(false);
     const [saved, setSaved] = useState(false);
 
     useEffect(() => {
@@ -22,28 +21,27 @@ export default function Settings({ navigate }: SettingsProps) {
             setDataDir_(s.data_dir);
             setDefaultDataDir(s.default_data_dir);
             setOverride(s.data_dir_override);
-            setDraftOverride(s.data_dir_override ?? "");
         });
     }, []);
 
-    async function handleSaveOverride() {
-        const value = draftOverride.trim() || null;
-        await setDataDir(value);
-        setOverride(value);
-        setEditing(false);
-        setSaved(true);
-    }
-
-    function handleCancelEdit() {
-        setDraftOverride(override_ ?? "");
-        setEditing(false);
+    async function handlePickFolder() {
+        const selected = await openDialog({
+            directory: true,
+            title: "Choose data directory",
+            defaultPath: dataDir,
+        });
+        if (selected) {
+            await setDataDir(selected);
+            setOverride(selected);
+            setDataDir_(selected);
+            setSaved(true);
+        }
     }
 
     async function handleReset() {
         await setDataDir(null);
         setOverride(null);
-        setDraftOverride("");
-        setEditing(false);
+        setDataDir_(defaultDataDir);
         setSaved(true);
     }
 
@@ -93,46 +91,27 @@ export default function Settings({ navigate }: SettingsProps) {
                             </button>
                         </div>
 
-                        {!editing ? (
-                            <div className={styles.overrideActions}>
-                                {override_ && (
-                                    <div className={styles.overrideNote}>
-                                        Custom path set (default: {defaultDataDir})
-                                    </div>
-                                )}
+                        <div className={styles.overrideActions}>
+                            {override_ && (
+                                <div className={styles.overrideNote}>
+                                    Custom path (default: {defaultDataDir})
+                                </div>
+                            )}
+                            <button
+                                className={styles.pathBtn}
+                                onClick={handlePickFolder}
+                            >
+                                {override_ ? "Change" : "Set custom path"}
+                            </button>
+                            {override_ && (
                                 <button
                                     className={styles.pathBtn}
-                                    onClick={() => setEditing(true)}
+                                    onClick={handleReset}
                                 >
-                                    {override_ ? "Change" : "Set custom path"}
+                                    Reset to default
                                 </button>
-                                {override_ && (
-                                    <button
-                                        className={styles.pathBtn}
-                                        onClick={handleReset}
-                                    >
-                                        Reset to default
-                                    </button>
-                                )}
-                            </div>
-                        ) : (
-                            <div className={styles.editRow}>
-                                <input
-                                    className={styles.pathInput}
-                                    type="text"
-                                    value={draftOverride}
-                                    onChange={(e) => setDraftOverride(e.target.value)}
-                                    placeholder={defaultDataDir}
-                                    autoFocus
-                                />
-                                <button className={styles.pathBtn} onClick={handleSaveOverride}>
-                                    Save
-                                </button>
-                                <button className={styles.pathBtn} onClick={handleCancelEdit}>
-                                    Cancel
-                                </button>
-                            </div>
-                        )}
+                            )}
+                        </div>
 
                         {saved && (
                             <div className={styles.restartNote}>

--- a/src/types.ts
+++ b/src/types.ts
@@ -94,3 +94,36 @@ export interface MinecraftProfile {
     id: string;
     name: string;
 }
+
+// Install progress
+
+export interface InstallProgress {
+    stage:
+        | "downloading"
+        | "parsing"
+        | "installing_mods"
+        | "extracting_overrides"
+        | "installing_loader"
+        | "finalizing"
+        | "complete"
+        | "failed";
+    message: string;
+    current: number;
+    total: number;
+    bytes_downloaded: number;
+    bytes_total: number;
+    project_id: string;
+}
+
+// Game events
+
+export interface GameLogEvent {
+    instance_id: string;
+    line: string;
+    stream: "stdout" | "stderr";
+}
+
+export interface GameExitEvent {
+    instance_id: string;
+    exit_code: number | null;
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -126,4 +126,5 @@ export interface GameLogEvent {
 export interface GameExitEvent {
     instance_id: string;
     exit_code: number | null;
+    crash_log: string | null;
 }


### PR DESCRIPTION
- **Modpack installation**: Download and install modpacks from Modrinth (mrpack format) with Fabric loader support
- **Game launch**: Full Minecraft launch pipeline — Java resolution (with Adoptium auto-download), version manifest handling, library/asset downloads, and process spawning with log streaming
- **Crash reporting**: Capture last 50 stderr lines and display crash log in the UI when the game exits with a non-zero code
- **Play button UX**: Immediate "Preparing..." feedback on click instead of silent delay while Java/assets resolve
- **Launch fixes**: Properly handle feature-gated version JSON rules (was incorrectly including `--demo` flag), deduplicate libraries when merging mod loader versions (prevents ASM/LWJGL classpath conflicts)
- **Settings**: Data directory shown in settings with native folder picker to override, persisted in `settings.json`