### PR TITLE
feat: preset support, game dir rename, folder button

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1106,9 +1106,6 @@
                 "arm"
             ],
             "dev": true,
-            "libc": [
-                "glibc"
-            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -1123,9 +1120,6 @@
                 "arm"
             ],
             "dev": true,
-            "libc": [
-                "musl"
-            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -1140,9 +1134,6 @@
                 "arm64"
             ],
             "dev": true,
-            "libc": [
-                "glibc"
-            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -1157,9 +1148,6 @@
                 "arm64"
             ],
             "dev": true,
-            "libc": [
-                "musl"
-            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -1174,9 +1162,6 @@
                 "loong64"
             ],
             "dev": true,
-            "libc": [
-                "glibc"
-            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -1191,9 +1176,6 @@
                 "loong64"
             ],
             "dev": true,
-            "libc": [
-                "musl"
-            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -1208,9 +1190,6 @@
                 "ppc64"
             ],
             "dev": true,
-            "libc": [
-                "glibc"
-            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -1225,9 +1204,6 @@
                 "ppc64"
             ],
             "dev": true,
-            "libc": [
-                "musl"
-            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -1242,9 +1218,6 @@
                 "riscv64"
             ],
             "dev": true,
-            "libc": [
-                "glibc"
-            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -1259,9 +1232,6 @@
                 "riscv64"
             ],
             "dev": true,
-            "libc": [
-                "musl"
-            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -1276,9 +1246,6 @@
                 "s390x"
             ],
             "dev": true,
-            "libc": [
-                "glibc"
-            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -1293,9 +1260,6 @@
                 "x64"
             ],
             "dev": true,
-            "libc": [
-                "glibc"
-            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -1310,9 +1274,6 @@
                 "x64"
             ],
             "dev": true,
-            "libc": [
-                "musl"
-            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -1502,9 +1463,6 @@
                 "arm64"
             ],
             "dev": true,
-            "libc": [
-                "glibc"
-            ],
             "license": "Apache-2.0 OR MIT",
             "optional": true,
             "os": [
@@ -1522,9 +1480,6 @@
                 "arm64"
             ],
             "dev": true,
-            "libc": [
-                "musl"
-            ],
             "license": "Apache-2.0 OR MIT",
             "optional": true,
             "os": [
@@ -1542,9 +1497,6 @@
                 "riscv64"
             ],
             "dev": true,
-            "libc": [
-                "glibc"
-            ],
             "license": "Apache-2.0 OR MIT",
             "optional": true,
             "os": [
@@ -1562,9 +1514,6 @@
                 "x64"
             ],
             "dev": true,
-            "libc": [
-                "glibc"
-            ],
             "license": "Apache-2.0 OR MIT",
             "optional": true,
             "os": [
@@ -1582,9 +1531,6 @@
                 "x64"
             ],
             "dev": true,
-            "libc": [
-                "musl"
-            ],
             "license": "Apache-2.0 OR MIT",
             "optional": true,
             "os": [

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -749,27 +749,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "dbus"
-version = "0.9.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21b3aa68d7e7abee336255bd7248ea965cc393f3e70411135a6f6a4b651345d4"
-dependencies = [
- "libc",
- "libdbus-sys",
- "windows-sys 0.59.0",
-]
-
-[[package]]
-name = "dbus-secret-service"
-version = "4.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "708b509edf7889e53d7efb0ffadd994cc6c2345ccb62f55cfd6b0682165e4fa6"
-dependencies = [
- "dbus",
- "zeroize",
-]
-
-[[package]]
 name = "deflate64"
 version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2157,7 +2136,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eebcc3aff044e5944a8fbaf69eb277d11986064cba30c468730e8b9909fb551c"
 dependencies = [
  "byteorder",
- "dbus-secret-service",
  "log",
  "security-framework 2.11.1",
  "security-framework 3.7.0",
@@ -2212,15 +2190,6 @@ name = "libc"
 version = "0.2.183"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b5b646652bf6661599e1da8901b3b9522896f01e736bad5f723fe7a3a27f899d"
-
-[[package]]
-name = "libdbus-sys"
-version = "0.2.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "328c4789d42200f1eeec05bd86c9c13c7f091d2ba9a6ea35acdf51f31bc0f043"
-dependencies = [
- "pkg-config",
-]
 
 [[package]]
 name = "libloading"

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -33,14 +33,12 @@ uuid = { version = "1", features = ["v4"] }
 chrono = { version = "0.4", features = ["serde"] }
 futures = "0.3"
 url = "2"
-keyring = { version = "3", features = [
-    "apple-native",
-    "windows-native",
-    "sync-secret-service",
-] }
 flate2 = "1"
 tar = "0.4"
 tauri-plugin-dialog = "2.6.0"
+
+[target.'cfg(not(target_os = "linux"))'.dependencies]
+keyring = { version = "3", features = ["apple-native", "windows-native"] }
 
 [profile.release]
 strip = true

--- a/src-tauri/src/auth/keychain.rs
+++ b/src-tauri/src/auth/keychain.rs
@@ -1,33 +1,93 @@
+use std::path::Path;
+
 use crate::error::GlowberryError;
 
+#[cfg(not(target_os = "linux"))]
 const SERVICE_NAME: &str = "com.glowberry.launcher";
+#[cfg(not(target_os = "linux"))]
 const REFRESH_TOKEN_KEY: &str = "msa_refresh_token";
 
-pub fn save_refresh_token(token: &str) -> Result<(), GlowberryError> {
-    let entry = keyring::Entry::new(SERVICE_NAME, REFRESH_TOKEN_KEY)
-        .map_err(|e| GlowberryError::Auth(format!("Keychain error: {e}")))?;
-    entry
-        .set_password(token)
+const TOKEN_FILE: &str = "refresh_token";
+
+pub fn save_refresh_token(token: &str, data_dir: &Path) -> Result<(), GlowberryError> {
+    #[cfg(target_os = "linux")]
+    return save_to_file(token, data_dir);
+
+    #[cfg(not(target_os = "linux"))]
+    {
+        let _ = data_dir;
+        let entry = keyring::Entry::new(SERVICE_NAME, REFRESH_TOKEN_KEY)
+            .map_err(|e| GlowberryError::Auth(format!("Keychain error: {e}")))?;
+        entry
+            .set_password(token)
+            .map_err(|e| GlowberryError::Auth(format!("Failed to save token: {e}")))?;
+        Ok(())
+    }
+}
+
+pub fn load_refresh_token(data_dir: &Path) -> Result<Option<String>, GlowberryError> {
+    #[cfg(target_os = "linux")]
+    return load_from_file(data_dir);
+
+    #[cfg(not(target_os = "linux"))]
+    {
+        let _ = data_dir;
+        let entry = keyring::Entry::new(SERVICE_NAME, REFRESH_TOKEN_KEY)
+            .map_err(|e| GlowberryError::Auth(format!("Keychain error: {e}")))?;
+        match entry.get_password() {
+            Ok(token) => Ok(Some(token)),
+            Err(keyring::Error::NoEntry) => Ok(None),
+            Err(e) => Err(GlowberryError::Auth(format!("Failed to load token: {e}"))),
+        }
+    }
+}
+
+pub fn delete_refresh_token(data_dir: &Path) -> Result<(), GlowberryError> {
+    #[cfg(target_os = "linux")]
+    return delete_from_file(data_dir);
+
+    #[cfg(not(target_os = "linux"))]
+    {
+        let _ = data_dir;
+        let entry = keyring::Entry::new(SERVICE_NAME, REFRESH_TOKEN_KEY)
+            .map_err(|e| GlowberryError::Auth(format!("Keychain error: {e}")))?;
+        match entry.delete_credential() {
+            Ok(()) => Ok(()),
+            Err(keyring::Error::NoEntry) => Ok(()),
+            Err(e) => Err(GlowberryError::Auth(format!("Failed to delete token: {e}"))),
+        }
+    }
+}
+
+#[cfg(target_os = "linux")]
+fn save_to_file(token: &str, data_dir: &Path) -> Result<(), GlowberryError> {
+    use std::fs;
+    use std::os::unix::fs::PermissionsExt;
+
+    let path = data_dir.join(TOKEN_FILE);
+    fs::write(&path, token)
         .map_err(|e| GlowberryError::Auth(format!("Failed to save token: {e}")))?;
+    fs::set_permissions(&path, fs::Permissions::from_mode(0o600))
+        .map_err(|e| GlowberryError::Auth(format!("Failed to set token permissions: {e}")))?;
     Ok(())
 }
 
-pub fn load_refresh_token() -> Result<Option<String>, GlowberryError> {
-    let entry = keyring::Entry::new(SERVICE_NAME, REFRESH_TOKEN_KEY)
-        .map_err(|e| GlowberryError::Auth(format!("Keychain error: {e}")))?;
-    match entry.get_password() {
-        Ok(token) => Ok(Some(token)),
-        Err(keyring::Error::NoEntry) => Ok(None),
+#[cfg(target_os = "linux")]
+fn load_from_file(data_dir: &Path) -> Result<Option<String>, GlowberryError> {
+    let path = data_dir.join(TOKEN_FILE);
+    match std::fs::read_to_string(&path) {
+        Ok(token) => Ok(Some(token.trim().to_string())),
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(None),
         Err(e) => Err(GlowberryError::Auth(format!("Failed to load token: {e}"))),
     }
 }
 
-pub fn delete_refresh_token() -> Result<(), GlowberryError> {
-    let entry = keyring::Entry::new(SERVICE_NAME, REFRESH_TOKEN_KEY)
-        .map_err(|e| GlowberryError::Auth(format!("Keychain error: {e}")))?;
-    match entry.delete_credential() {
+#[cfg(target_os = "linux")]
+fn delete_from_file(data_dir: &Path) -> Result<(), GlowberryError> {
+    let path = data_dir.join(TOKEN_FILE);
+    match std::fs::remove_file(&path) {
         Ok(()) => Ok(()),
-        Err(keyring::Error::NoEntry) => Ok(()),
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(()),
         Err(e) => Err(GlowberryError::Auth(format!("Failed to delete token: {e}"))),
     }
 }

--- a/src-tauri/src/commands/auth.rs
+++ b/src-tauri/src/commands/auth.rs
@@ -99,10 +99,9 @@ pub async fn start_login(
 
             eprintln!("[auth] login complete: {}", profile.name);
 
-            keychain::save_refresh_token(&auth_tokens.msa_refresh_token)?;
-
             {
                 let state = app_bg.state::<AppState>();
+                keychain::save_refresh_token(&auth_tokens.msa_refresh_token, &state.data_dir)?;
                 let mut auth = state.auth.lock().unwrap();
                 auth.profile = Some(profile.clone());
                 auth.tokens = Some(auth_tokens);
@@ -154,7 +153,7 @@ pub fn get_auth_status(state: State<'_, AppState>) -> Option<MinecraftProfile> {
 pub async fn try_restore_session(
     state: State<'_, AppState>,
 ) -> Result<Option<MinecraftProfile>, GlowberryError> {
-    let refresh_token = match keychain::load_refresh_token()? {
+    let refresh_token = match keychain::load_refresh_token(&state.data_dir)? {
         Some(t) => t,
         None => return Ok(None),
     };
@@ -165,7 +164,7 @@ pub async fn try_restore_session(
         Ok(tokens) => tokens,
         Err(e) => {
             eprintln!("[auth] refresh failed: {e}");
-            let _ = keychain::delete_refresh_token();
+            let _ = keychain::delete_refresh_token(&state.data_dir);
             return Ok(None);
         }
     };
@@ -181,14 +180,14 @@ pub async fn try_restore_session(
         Ok(result) => result,
         Err(e) => {
             eprintln!("[auth] token exchange failed during restore: {e}");
-            let _ = keychain::delete_refresh_token();
+            let _ = keychain::delete_refresh_token(&state.data_dir);
             return Ok(None);
         }
     };
 
     eprintln!("[auth] session restored: {}", profile.name);
 
-    keychain::save_refresh_token(&auth_tokens.msa_refresh_token)?;
+    keychain::save_refresh_token(&auth_tokens.msa_refresh_token, &state.data_dir)?;
 
     {
         let mut auth = state.auth.lock().unwrap();
@@ -207,7 +206,7 @@ pub fn logout(state: State<'_, AppState>) -> Result<(), GlowberryError> {
         auth.profile = None;
         auth.tokens = None;
     }
-    keychain::delete_refresh_token()?;
+    keychain::delete_refresh_token(&state.data_dir)?;
     eprintln!("[auth] logged out");
     Ok(())
 }

--- a/src-tauri/src/commands/folder.rs
+++ b/src-tauri/src/commands/folder.rs
@@ -1,0 +1,19 @@
+use tauri::State;
+use tauri_plugin_opener::OpenerExt;
+
+use crate::error::GlowberryError;
+use crate::state::AppState;
+
+/// Open the Glowberry data folder in the system file manager.
+#[tauri::command]
+pub async fn open_data_folder(
+    app: tauri::AppHandle,
+    state: State<'_, AppState>,
+) -> Result<(), GlowberryError> {
+    let url = url::Url::from_file_path(&state.data_dir)
+        .map_err(|_| GlowberryError::Other("Invalid data directory path".into()))?;
+    app.opener()
+        .open_url(url.as_str(), None::<&str>)
+        .map_err(|e| GlowberryError::Other(e.to_string()))?;
+    Ok(())
+}

--- a/src-tauri/src/commands/github.rs
+++ b/src-tauri/src/commands/github.rs
@@ -9,13 +9,13 @@ const GITHUB_REPO: &str = "matejstastny/starlight";
 #[derive(Debug, Clone, Serialize)]
 pub struct GithubRelease {
     pub tag: String,
-    pub mrpack_url: String,
-    pub mrpack_name: String,
-    pub mrpack_size: u64,
+    pub asset_url: String,
+    pub asset_name: String,
+    pub asset_size: u64,
 }
 
 /// Fetch the latest GitHub release for the Starlight modpack.
-/// Returns `None` if there are no releases yet or no client mrpack asset is attached.
+/// Returns `None` if there are no releases yet or no presets zip asset is attached.
 #[tauri::command]
 pub async fn check_starlight_update(
     state: State<'_, AppState>,
@@ -30,7 +30,6 @@ pub async fn check_starlight_update(
         .send()
         .await?;
 
-    // 404 = no releases yet
     if resp.status().as_u16() == 404 {
         return Ok(None);
     }
@@ -51,31 +50,42 @@ pub async fn check_starlight_update(
         None => return Ok(None),
     };
 
-    // Find the *-client.mrpack asset — absent if the release is still being published
-    let asset = match assets.iter().find(|a| {
-        a["name"]
-            .as_str()
-            .is_some_and(|n| n.ends_with("-client.mrpack"))
-    }) {
+    // Prefer a presets zip; fall back to a plain client mrpack for older releases.
+    let asset = assets
+        .iter()
+        .find(|a| {
+            a["name"]
+                .as_str()
+                .is_some_and(|n| n.ends_with("-client-presets.zip"))
+        })
+        .or_else(|| {
+            assets.iter().find(|a| {
+                a["name"]
+                    .as_str()
+                    .is_some_and(|n| n.ends_with("-client.mrpack"))
+            })
+        });
+
+    let asset = match asset {
         Some(a) => a,
         None => return Ok(None),
     };
 
-    let mrpack_url = asset["browser_download_url"]
+    let asset_url = asset["browser_download_url"]
         .as_str()
         .unwrap_or("")
         .to_string();
-    let mrpack_name = asset["name"].as_str().unwrap_or("").to_string();
-    let mrpack_size = asset["size"].as_u64().unwrap_or(0);
+    let asset_name = asset["name"].as_str().unwrap_or("").to_string();
+    let asset_size = asset["size"].as_u64().unwrap_or(0);
 
-    if mrpack_url.is_empty() {
+    if asset_url.is_empty() {
         return Ok(None);
     }
 
     Ok(Some(GithubRelease {
         tag,
-        mrpack_url,
-        mrpack_name,
-        mrpack_size,
+        asset_url,
+        asset_name,
+        asset_size,
     }))
 }

--- a/src-tauri/src/commands/install.rs
+++ b/src-tauri/src/commands/install.rs
@@ -5,20 +5,19 @@ use crate::instance::manager::Instance;
 use crate::minecraft::install;
 use crate::state::AppState;
 
-/// Install (or update in place) the Starlight modpack from a GitHub release URL.
+/// Install (or update in place) the Starlight modpack from a GitHub release asset.
 #[tauri::command]
 pub async fn install_starlight(
     app: AppHandle,
     state: State<'_, AppState>,
-    mrpack_url: String,
-    mrpack_name: String,
-    mrpack_size: u64,
+    asset_url: String,
+    asset_name: String,
+    asset_size: u64,
     version_tag: String,
 ) -> Result<Instance, GlowberryError> {
-    // Find existing Starlight instance to reuse its ID (in-place update)
-    let existing_id = {
+    let (existing_id, existing_active_preset) = {
         let instances = state.instances.lock().unwrap();
-        instances
+        let existing = instances
             .list()
             .unwrap_or_default()
             .into_iter()
@@ -26,18 +25,22 @@ pub async fn install_starlight(
                 i.modpack
                     .as_ref()
                     .is_some_and(|m| m.project_slug == "starlightmodpack")
-            })
-            .map(|i| i.id)
+            });
+        (
+            existing.as_ref().map(|i| i.id.clone()),
+            existing.and_then(|i| i.active_preset),
+        )
     };
 
     install::install_from_github(
         app,
         &state,
-        mrpack_url,
-        mrpack_name,
-        mrpack_size,
+        asset_url,
+        asset_name,
+        asset_size,
         version_tag,
         existing_id,
+        existing_active_preset,
     )
     .await
 }

--- a/src-tauri/src/commands/mod.rs
+++ b/src-tauri/src/commands/mod.rs
@@ -1,5 +1,7 @@
 pub mod auth;
+pub mod folder;
 pub mod github;
 pub mod install;
 pub mod instances;
 pub mod launch;
+pub mod presets;

--- a/src-tauri/src/commands/presets.rs
+++ b/src-tauri/src/commands/presets.rs
@@ -1,0 +1,83 @@
+use tauri::State;
+
+use crate::error::GlowberryError;
+use crate::instance::manager::Instance;
+use crate::modrinth::mrpack::extract_overrides;
+use crate::state::AppState;
+
+/// Return sorted preset names available for an instance.
+#[tauri::command]
+pub async fn list_presets(
+    state: State<'_, AppState>,
+    instance_id: String,
+) -> Result<Vec<String>, GlowberryError> {
+    let presets_dir = state
+        .data_dir
+        .join("instances")
+        .join(&instance_id)
+        .join("presets");
+
+    if !presets_dir.exists() {
+        return Ok(vec![]);
+    }
+
+    let mut names = Vec::new();
+    for entry in std::fs::read_dir(&presets_dir)? {
+        let entry = entry?;
+        let path = entry.path();
+        if path.extension().and_then(|e| e.to_str()) == Some("mrpack") {
+            if let Some(stem) = path.file_stem().and_then(|s| s.to_str()) {
+                names.push(stem.to_string());
+            }
+        }
+    }
+    names.sort();
+    Ok(names)
+}
+
+/// Apply a preset's overrides to the instance game directory and persist the
+/// active preset on the instance. Saves/ and servers.dat are never touched.
+#[tauri::command]
+pub async fn switch_preset(
+    state: State<'_, AppState>,
+    instance_id: String,
+    preset_name: String,
+) -> Result<Instance, GlowberryError> {
+    let instance_dir = state.data_dir.join("instances").join(&instance_id);
+    let preset_path = instance_dir
+        .join("presets")
+        .join(format!("{preset_name}.mrpack"));
+
+    if !preset_path.exists() {
+        return Err(GlowberryError::Other(format!(
+            "Preset '{preset_name}' not found"
+        )));
+    }
+
+    let game_dir = instance_dir.join("game");
+    tokio::fs::create_dir_all(&game_dir).await?;
+
+    let mut locked = std::collections::HashSet::new();
+    locked.insert("saves/".to_string());
+    locked.insert("servers.dat".to_string());
+
+    let preset_path_clone = preset_path.clone();
+    let game_dir_clone = game_dir.clone();
+    tokio::task::spawn_blocking(move || {
+        extract_overrides(&preset_path_clone, &game_dir_clone, &locked)
+    })
+    .await
+    .map_err(|e| GlowberryError::Other(format!("Extract task failed: {e}")))??;
+
+    let mut instance = {
+        let instances = state.instances.lock().unwrap();
+        instances.get(&instance_id)?
+    };
+    instance.active_preset = Some(preset_name);
+    {
+        let instances = state.instances.lock().unwrap();
+        instances.save(&instance)?;
+    }
+
+    Ok(instance)
+}

--- a/src-tauri/src/instance/manager.rs
+++ b/src-tauri/src/instance/manager.rs
@@ -19,6 +19,8 @@ pub struct Instance {
     pub last_played: Option<DateTime<Utc>>,
     pub jvm_args: Vec<String>,
     pub memory_mb: u32,
+    #[serde(default)]
+    pub active_preset: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -38,6 +38,11 @@ pub fn run() {
             commands::github::check_starlight_update,
             // Launch
             commands::launch::launch_instance,
+            // Presets
+            commands::presets::list_presets,
+            commands::presets::switch_preset,
+            // Folder
+            commands::folder::open_data_folder,
         ])
         .run(tauri::generate_context!())
         .expect("error while running Glowberry");

--- a/src-tauri/src/minecraft/install.rs
+++ b/src-tauri/src/minecraft/install.rs
@@ -1,4 +1,5 @@
 use std::collections::HashMap;
+use std::path::Path;
 use std::sync::atomic::{AtomicU32, Ordering};
 use std::sync::Arc;
 
@@ -40,84 +41,102 @@ fn emit_progress(app: &AppHandle, progress: &InstallProgress) {
     let _ = app.emit("install-progress", progress);
 }
 
-async fn clean_minecraft_dir_preserve_saves(
-    minecraft_dir: &std::path::Path,
-) -> Result<(), GlowberryError> {
-    if !minecraft_dir.exists() {
+/// Clean game dir, keeping saves/ and servers.dat intact.
+async fn clean_game_dir_preserve_persistent(game_dir: &Path) -> Result<(), GlowberryError> {
+    if !game_dir.exists() {
         return Ok(());
     }
-
-    let mut entries = tokio::fs::read_dir(minecraft_dir).await?;
+    let mut entries = tokio::fs::read_dir(game_dir).await?;
     while let Some(entry) = entries.next_entry().await? {
-        let path = entry.path();
         let name = entry.file_name();
-
-        // Preserve player worlds
-        if name.to_string_lossy() == "saves" {
+        let name_str = name.to_string_lossy();
+        if name_str == "saves" || name_str == "servers.dat" {
             continue;
         }
-
-        let file_type = entry.file_type().await?;
-        if file_type.is_dir() {
+        let path = entry.path();
+        if entry.file_type().await?.is_dir() {
             tokio::fs::remove_dir_all(path).await?;
         } else {
             tokio::fs::remove_file(path).await?;
         }
     }
-
     Ok(())
 }
 
-/// Install (or update) the Starlight modpack from a direct mrpack download URL.
-/// If `existing_instance_id` is provided, the existing instance directory is
-/// reused (in-place update); otherwise a fresh UUID is generated.
+/// Extract each top-level *.mrpack from a zip into presets_dir.
+/// Returns the sorted list of preset names (file stems).
+fn extract_preset_mrpacks(zip_path: &Path, presets_dir: &Path) -> Result<Vec<String>, GlowberryError> {
+    let file = std::fs::File::open(zip_path)?;
+    let mut archive = zip::ZipArchive::new(file)?;
+    let mut names = Vec::new();
+
+    for i in 0..archive.len() {
+        let mut entry = archive.by_index(i)?;
+        let entry_name = entry.name().to_string();
+
+        if entry_name.ends_with(".mrpack") && !entry_name.contains('/') {
+            let dest = presets_dir.join(&entry_name);
+            let mut outfile = std::fs::File::create(&dest)?;
+            std::io::copy(&mut entry, &mut outfile)?;
+
+            if let Some(stem) = Path::new(&entry_name).file_stem().and_then(|s| s.to_str()) {
+                names.push(stem.to_string());
+            }
+        }
+    }
+
+    names.sort();
+    Ok(names)
+}
+
+/// Install (or update) the Starlight modpack from a GitHub release asset.
+/// The asset is either a presets zip (*-client-presets.zip) or a plain mrpack
+/// (*-client.mrpack) for older releases.
 pub async fn install_from_github(
     app: AppHandle,
     state: &AppState,
-    mrpack_url: String,
-    mrpack_name: String,
-    mrpack_size: u64,
+    asset_url: String,
+    asset_name: String,
+    asset_size: u64,
     version_tag: String,
     existing_instance_id: Option<String>,
+    existing_active_preset: Option<String>,
 ) -> Result<Instance, GlowberryError> {
     const SLUG: &str = "starlightmodpack";
     let client = &state.http_client;
 
-    // Fetch project metadata from Modrinth (icon URL, title)
     let api = ModrinthApi::new(client.clone());
     let (pack_title, icon_url) = match api.get_project(SLUG).await {
         Ok(p) => (p.title, p.icon_url),
         Err(_) => ("Starlight".to_string(), None),
     };
 
-    // Stage: Downloading mrpack
     emit_progress(
         &app,
         &InstallProgress {
             stage: InstallStage::Downloading,
-            message: format!("Downloading {mrpack_name}..."),
+            message: format!("Downloading {asset_name}..."),
             current: 0,
             total: 1,
             bytes_downloaded: 0,
-            bytes_total: mrpack_size,
+            bytes_total: asset_size,
             project_id: SLUG.to_string(),
         },
     );
 
     let temp_dir = state.data_dir.join("temp");
     tokio::fs::create_dir_all(&temp_dir).await?;
-    let mrpack_path = temp_dir.join(&mrpack_name);
+    let asset_path = temp_dir.join(&asset_name);
 
-    let dm = DownloadManager::new(client.clone());
-    dm.download_file(&DownloadTask {
-        url: mrpack_url,
-        dest: mrpack_path.clone(),
-        expected_hash: ExpectedHash::None, // GitHub releases don't provide sha512 in the API
-        file_name: mrpack_name.clone(),
-    })
-    .await?;
+    DownloadManager::new(client.clone())
+        .download_file(&DownloadTask {
+            url: asset_url,
+            dest: asset_path.clone(),
+            expected_hash: ExpectedHash::None,
+            file_name: asset_name.clone(),
+        })
+        .await?;
 
-    // Stage: Parsing — from here the pipeline is identical to install_modpack
     emit_progress(
         &app,
         &InstallProgress {
@@ -131,8 +150,59 @@ pub async fn install_from_github(
         },
     );
 
-    let mrpack_path_clone = mrpack_path.clone();
-    let index = tokio::task::spawn_blocking(move || parse_mrpack(&mrpack_path_clone))
+    let is_update = existing_instance_id.is_some();
+    let instance_id = existing_instance_id.unwrap_or_else(|| uuid::Uuid::new_v4().to_string());
+    let instance_dir = state.data_dir.join("instances").join(&instance_id);
+    let game_dir = instance_dir.join("game");
+    let presets_dir = instance_dir.join("presets");
+
+    tokio::fs::create_dir_all(&game_dir).await?;
+
+    // Determine active preset and extract mrpacks from zip (or treat plain mrpack as "default")
+    let (active_preset, mrpack_for_parsing) = if asset_name.ends_with("-client-presets.zip") {
+        // Clear old presets and extract fresh ones
+        if presets_dir.exists() {
+            tokio::fs::remove_dir_all(&presets_dir).await?;
+        }
+        tokio::fs::create_dir_all(&presets_dir).await?;
+
+        let asset_path_clone = asset_path.clone();
+        let presets_dir_clone = presets_dir.clone();
+        let preset_names = tokio::task::spawn_blocking(move || {
+            extract_preset_mrpacks(&asset_path_clone, &presets_dir_clone)
+        })
+        .await
+        .map_err(|e| GlowberryError::Other(format!("Preset extraction failed: {e}")))??;
+
+        if preset_names.is_empty() {
+            return Err(GlowberryError::Other(
+                "No presets found in the release archive".into(),
+            ));
+        }
+
+        // Restore previous preset if it still exists; otherwise fall back to first and notify.
+        let active = match &existing_active_preset {
+            Some(prev) if preset_names.contains(prev) => prev.clone(),
+            Some(prev) => {
+                let fallback = preset_names[0].clone();
+                let _ = app.emit(
+                    "preset-fallback",
+                    serde_json::json!({ "requested": prev, "applied": fallback }),
+                );
+                fallback
+            }
+            None => preset_names[0].clone(),
+        };
+
+        let mrpack = presets_dir.join(format!("{active}.mrpack"));
+        (Some(active), mrpack)
+    } else {
+        // Plain mrpack (legacy / no-preset release)
+        (None, asset_path.clone())
+    };
+
+    let mrpack_clone = mrpack_for_parsing.clone();
+    let index = tokio::task::spawn_blocking(move || parse_mrpack(&mrpack_clone))
         .await
         .map_err(|e| GlowberryError::Other(format!("Parse task failed: {e}")))??;
 
@@ -159,21 +229,12 @@ pub async fn install_from_github(
         (ModLoader::Vanilla, None)
     };
 
-    let is_update = existing_instance_id.is_some();
-    let instance_id = existing_instance_id.unwrap_or_else(|| uuid::Uuid::new_v4().to_string());
-    let minecraft_dir = state
-        .data_dir
-        .join("instances")
-        .join(&instance_id)
-        .join(".minecraft");
-    tokio::fs::create_dir_all(&minecraft_dir).await?;
-
     if is_update {
         emit_progress(
             &app,
             &InstallProgress {
                 stage: InstallStage::Finalizing,
-                message: "Cleaning old files (keeping worlds)...".into(),
+                message: "Cleaning old files (keeping worlds and server list)...".into(),
                 current: 0,
                 total: 0,
                 bytes_downloaded: 0,
@@ -181,10 +242,9 @@ pub async fn install_from_github(
                 project_id: SLUG.to_string(),
             },
         );
-        clean_minecraft_dir_preserve_saves(&minecraft_dir).await?;
+        clean_game_dir_preserve_persistent(&game_dir).await?;
     }
 
-    // Filter: skip server-only files
     let mod_files: Vec<_> = index
         .files
         .iter()
@@ -221,10 +281,8 @@ pub async fn install_from_github(
             .first()
             .ok_or_else(|| GlowberryError::Other(format!("No download URL for {}", mf.path)))?
             .clone();
-
-        let dest = minecraft_dir.join(&mf.path);
+        let dest = game_dir.join(&mf.path);
         file_hashes.insert(mf.path.clone(), mf.hashes.sha512.clone());
-
         tasks.push(DownloadTask {
             url,
             dest,
@@ -238,7 +296,6 @@ pub async fn install_from_github(
         let dm = DownloadManager::new(client.clone());
         let completed = Arc::clone(&completed);
         let app_clone = app.clone();
-
         handles.push(tokio::spawn(async move {
             dm.download_file(&task).await?;
             let done = completed.fetch_add(1, Ordering::Relaxed) + 1;
@@ -257,7 +314,6 @@ pub async fn install_from_github(
             Ok::<(), GlowberryError>(())
         }));
     }
-
     for handle in handles {
         handle
             .await
@@ -277,14 +333,13 @@ pub async fn install_from_github(
         },
     );
 
-    let mc_dir_clone = minecraft_dir.clone();
-    let mrpack_path_clone2 = mrpack_path.clone();
+    let game_dir_clone = game_dir.clone();
+    let mrpack_clone2 = mrpack_for_parsing.clone();
+    let mut locked = std::collections::HashSet::new();
+    locked.insert("saves/".to_string());
+    locked.insert("servers.dat".to_string());
     let extracted = tokio::task::spawn_blocking(move || {
-        extract_overrides(
-            &mrpack_path_clone2,
-            &mc_dir_clone,
-            &std::collections::HashSet::new(),
-        )
+        extract_overrides(&mrpack_clone2, &game_dir_clone, &locked)
     })
     .await
     .map_err(|e| GlowberryError::Other(format!("Extract task failed: {e}")))??;
@@ -323,25 +378,23 @@ pub async fn install_from_github(
     );
 
     let manifest = serde_json::to_string_pretty(&file_hashes)?;
-    let instance_dir = state.data_dir.join("instances").join(&instance_id);
     tokio::fs::write(instance_dir.join("file_manifest.json"), manifest).await?;
 
-    let mrpack_path_clone3 = mrpack_path.clone();
+    let mrpack_clone3 = mrpack_for_parsing.clone();
     let index_json = tokio::task::spawn_blocking(move || -> Result<String, GlowberryError> {
-        let file = std::fs::File::open(&mrpack_path_clone3)?;
+        let file = std::fs::File::open(&mrpack_clone3)?;
         let mut archive = zip::ZipArchive::new(file)?;
-        let mut index_entry = archive.by_name("modrinth.index.json")?;
+        let mut entry = archive.by_name("modrinth.index.json")?;
         let mut contents = String::new();
-        std::io::Read::read_to_string(&mut index_entry, &mut contents)?;
+        std::io::Read::read_to_string(&mut entry, &mut contents)?;
         Ok(contents)
     })
     .await
     .map_err(|e| GlowberryError::Other(format!("Read index task failed: {e}")))??;
 
     tokio::fs::write(instance_dir.join("last_mrpack_index.json"), index_json).await?;
-    let _ = tokio::fs::remove_file(&mrpack_path).await;
+    let _ = tokio::fs::remove_file(&asset_path).await;
 
-    // Preserve memory_mb from an existing instance if we have one
     let memory_mb = {
         let instances = state.instances.lock().unwrap();
         instances
@@ -370,6 +423,7 @@ pub async fn install_from_github(
         last_played: None,
         jvm_args: Vec::new(),
         memory_mb,
+        active_preset,
     };
 
     {

--- a/src-tauri/src/minecraft/launch.rs
+++ b/src-tauri/src/minecraft/launch.rs
@@ -83,7 +83,7 @@ pub async fn launch_instance(
     .await?;
 
     // 3. If using a mod loader, merge version JSONs
-    let version_json = match (&instance.loader, &instance.loader_version) {
+    let mut version_json = match (&instance.loader, &instance.loader_version) {
         (ModLoader::Fabric, Some(loader_ver)) => {
             let fabric_json_path = super::fabric::install_fabric(
                 client,
@@ -98,6 +98,13 @@ pub async fn launch_instance(
         }
         _ => vanilla_json,
     };
+
+    // On Linux aarch64, replace x86_64 LWJGL natives with arm64 equivalents.
+    #[cfg(all(target_os = "linux", target_arch = "aarch64"))]
+    {
+        eprintln!("[launch] Patching LWJGL natives for Linux aarch64...");
+        super::version::patch_lwjgl_for_linux_arm64(&mut version_json.libraries);
+    }
 
     // 4. Download client JAR
     let client_jar =
@@ -119,7 +126,7 @@ pub async fn launch_instance(
         .data_dir
         .join("instances")
         .join(&instance.id)
-        .join(".minecraft");
+        .join("game");
 
     let natives_dir = data_dir
         .join("versions")
@@ -194,6 +201,41 @@ pub async fn launch_instance(
     ];
     memory_args.extend(instance.jvm_args.clone());
 
+    // On Linux, inject HiDPI fixes.
+    //
+    // The root cause of Minecraft looking pixelated on HiDPI Wayland displays is
+    // that Minecraft's bundled GLFW falls back to XWayland, which has no HiDPI
+    // support. If a Wayland-capable system GLFW is installed (e.g. from the
+    // lyessaadi/minecraft-wayland-glfw Fedora COPR), override the LWJGL GLFW
+    // library path so Minecraft uses it instead of its bundled one. That lets
+    // GLFW negotiate the correct framebuffer scale with the Wayland compositor.
+    #[cfg(target_os = "linux")]
+    {
+        const GLFW_CANDIDATES: &[&str] = &[
+            "/usr/lib/libglfw.so",
+            "/usr/lib/libglfw.so.3",
+            "/usr/lib64/libglfw.so",
+            "/usr/lib64/libglfw.so.3",
+            "/usr/local/lib/libglfw.so",
+            "/usr/local/lib/libglfw.so.3",
+        ];
+        if let Some(glfw_path) = GLFW_CANDIDATES.iter().find(|p| std::path::Path::new(p).exists()) {
+            eprintln!("[launch] Found system GLFW at {glfw_path}, enabling Wayland HiDPI mode");
+            memory_args.push(format!("-Dorg.lwjgl.glfw.libname={glfw_path}"));
+        }
+
+        // Also scale Java2D (AWT/menus) to match the physical display scale.
+        let scale = app
+            .primary_monitor()
+            .ok()
+            .flatten()
+            .map(|m| m.scale_factor())
+            .unwrap_or(1.0);
+        if scale > 1.0 {
+            memory_args.push(format!("-Dsun.java2d.uiScale={}", scale.ceil() as u32));
+        }
+    }
+
     // 10. Ensure game directory exists
     tokio::fs::create_dir_all(&minecraft_dir).await?;
 
@@ -215,6 +257,16 @@ pub async fn launch_instance(
     cmd.current_dir(&minecraft_dir);
     cmd.stdout(std::process::Stdio::piped());
     cmd.stderr(std::process::Stdio::piped());
+
+    // On Linux, these env vars improve behaviour under Wayland compositors:
+    // - _JAVA_AWT_WM_NONREPARENTING: prevents AWT window-reparenting issues
+    // - GDK_SCALE=1: stops GDK from adding its own scaling on top of the
+    //   compositor's, which would otherwise double-scale Java windows
+    #[cfg(target_os = "linux")]
+    {
+        cmd.env("_JAVA_AWT_WM_NONREPARENTING", "1");
+        cmd.env("GDK_SCALE", "1");
+    }
 
     // On Windows, java.exe is a console-subsystem binary — without this flag
     // it opens a visible terminal window every time Minecraft launches.
@@ -409,7 +461,10 @@ async fn download_libraries(
             continue;
         }
 
-        let hash = sha1.map(ExpectedHash::Sha1).unwrap_or(ExpectedHash::None);
+        let hash = match sha1 {
+            Some(s) if !s.is_empty() => ExpectedHash::Sha1(s),
+            _ => ExpectedHash::None,
+        };
         let dm = Arc::clone(&dm);
 
         handles.push(tokio::spawn(async move {

--- a/src-tauri/src/minecraft/version.rs
+++ b/src-tauri/src/minecraft/version.rs
@@ -396,6 +396,60 @@ fn default_jvm_args(subs: &HashMap<&str, String>) -> Vec<String> {
     templates.iter().map(|t| substitute(t, subs)).collect()
 }
 
+/// On Linux aarch64, Mojang's version JSON only ships `natives-linux` (x86_64) JARs.
+/// This swaps every LWJGL `natives-linux` entry for a `natives-linux-arm64` one
+/// fetched from Maven Central, where LWJGL 3.3.x officially publishes arm64 builds.
+#[cfg(all(target_os = "linux", target_arch = "aarch64"))]
+pub fn patch_lwjgl_for_linux_arm64(libraries: &mut Vec<Library>) {
+    const MAVEN_CENTRAL: &str = "https://repo1.maven.org/maven2";
+
+    let mut replacements: Vec<(usize, Library)> = Vec::new();
+
+    for (i, lib) in libraries.iter().enumerate() {
+        if !lib.name.starts_with("org.lwjgl:") || !lib.name.ends_with(":natives-linux") {
+            continue;
+        }
+        let parts: Vec<&str> = lib.name.split(':').collect();
+        if parts.len() != 4 {
+            continue;
+        }
+        let group_path = parts[0].replace('.', "/");
+        let artifact = parts[1];
+        let version = parts[2];
+        let classifier = "natives-linux-arm64";
+        let filename = format!("{artifact}-{version}-{classifier}.jar");
+        let path = format!("{group_path}/{artifact}/{version}/{filename}");
+        let url = format!("{MAVEN_CENTRAL}/{path}");
+
+        replacements.push((
+            i,
+            Library {
+                name: format!("{}:{}:{}:{}", parts[0], parts[1], parts[2], classifier),
+                downloads: Some(LibraryDownloads {
+                    artifact: Some(LibraryArtifact {
+                        path,
+                        sha1: String::new(),
+                        size: 0,
+                        url,
+                    }),
+                }),
+                rules: Some(vec![Rule {
+                    action: "allow".to_string(),
+                    os: Some(OsRule {
+                        name: Some("linux".to_string()),
+                    }),
+                    features: None,
+                }]),
+                url: None,
+            },
+        ));
+    }
+
+    for (i, replacement) in replacements.into_iter().rev() {
+        libraries[i] = replacement;
+    }
+}
+
 // -- Fetch helpers for assets --
 
 pub async fn fetch_asset_index(

--- a/src-tauri/src/state.rs
+++ b/src-tauri/src/state.rs
@@ -25,11 +25,28 @@ pub struct AppState {
     pub data_dir: PathBuf,
 }
 
+fn migrate_game_dirs(data_dir: &std::path::Path) {
+    let instances_dir = data_dir.join("instances");
+    if !instances_dir.exists() {
+        return;
+    }
+    if let Ok(entries) = std::fs::read_dir(&instances_dir) {
+        for entry in entries.flatten() {
+            let old = entry.path().join(".minecraft");
+            let new = entry.path().join("game");
+            if old.exists() && !new.exists() {
+                let _ = std::fs::rename(&old, &new);
+            }
+        }
+    }
+}
+
 impl AppState {
     pub fn new(data_dir: PathBuf) -> Self {
         std::fs::create_dir_all(&data_dir).expect("Failed to create data directory");
         std::fs::create_dir_all(data_dir.join("instances"))
             .expect("Failed to create instances dir");
+        migrate_game_dirs(&data_dir);
         std::fs::create_dir_all(data_dir.join("versions")).expect("Failed to create versions dir");
         std::fs::create_dir_all(data_dir.join("assets")).expect("Failed to create assets dir");
         std::fs::create_dir_all(data_dir.join("libraries"))

--- a/src/App.module.css
+++ b/src/App.module.css
@@ -35,7 +35,8 @@
     cursor: default;
 }
 
-.settingsBtn {
+.settingsBtn,
+.folderBtn {
     /* no longer position:absolute – it lives inside .topBar */
     z-index: 120;
     width: 28px;
@@ -53,7 +54,8 @@
         background var(--transition);
 }
 
-.settingsBtn:hover {
+.settingsBtn:hover,
+.folderBtn:hover {
     color: var(--text-secondary);
     background: var(--bg-card);
 }
@@ -124,7 +126,78 @@
 .packVersion {
     font-size: 12px;
     color: var(--text-muted);
-    margin-bottom: 18px;
+    margin-bottom: 10px;
+}
+
+/* ── Preset switcher ────────────────────────────────────────── */
+
+.presetRow {
+    display: flex;
+    margin-bottom: 10px;
+    border: 1px solid var(--border);
+    border-radius: var(--radius-sm);
+    overflow: hidden;
+    max-width: 176px;
+    width: 176px;
+}
+
+.presetBtn {
+    flex: 1;
+    height: 26px;
+    min-width: 0;
+    background: transparent;
+    border: none;
+    border-left: 1px solid var(--border);
+    color: var(--text-muted);
+    font-size: 11px;
+    font-weight: 500;
+    font-family: inherit;
+    cursor: pointer;
+    transition: all var(--transition);
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    padding: 0 6px;
+}
+
+.presetBtn:first-child {
+    border-left: none;
+}
+
+.presetBtn:hover:not(.presetBtnActive):not(:disabled) {
+    background: var(--bg-card);
+    color: var(--text-secondary);
+}
+
+.presetBtnActive {
+    background: var(--accent-soft);
+    color: var(--accent);
+    cursor: default;
+}
+
+.presetBtnActive:disabled {
+    opacity: 1;
+}
+
+/* Preset fallback warning */
+.presetWarning {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    padding: 6px 10px;
+    margin-bottom: 8px;
+    background: rgba(212, 162, 76, 0.08);
+    border: 1px solid rgba(212, 162, 76, 0.25);
+    border-radius: var(--radius-sm);
+    width: 176px;
+}
+
+.presetWarningText {
+    flex: 1;
+    font-size: 10px;
+    color: var(--accent);
+    line-height: 1.4;
+    overflow: hidden;
 }
 
 .playBtn {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -4,6 +4,7 @@ import { tryRestoreSession } from "@/api/auth";
 import { listInstances } from "@/api/instances";
 import { installStarlight } from "@/api/install";
 import { checkStarlightUpdate } from "@/api/github";
+import { listPresets, switchPreset, openDataFolder } from "@/api/presets";
 import { launchInstance } from "@/api/launch";
 import { check as checkAppUpdate, type Update as AppUpdate } from "@tauri-apps/plugin-updater";
 import { getVersion } from "@tauri-apps/api/app";
@@ -84,6 +85,10 @@ export default function App() {
 
     const [showSettings, setShowSettings] = useState(false);
 
+    const [presets, setPresets] = useState<string[]>([]);
+    const [switchingPreset, setSwitchingPreset] = useState(false);
+    const [presetWarning, setPresetWarning] = useState<string | null>(null);
+
     // Show the window once React has painted the first frame.
     // The window starts hidden (visible:false in tauri.conf.json) to avoid
     // the blank WebView2 flash on Windows before content is ready.
@@ -162,6 +167,25 @@ export default function App() {
         };
     }, []);
 
+    // Preset fallback notification (emitted by Rust when the previous preset no longer exists)
+    useEffect(() => {
+        let cancelled = false;
+        let unsub: (() => void) | null = null;
+
+        listen<{ requested: string; applied: string }>("preset-fallback", (e) => {
+            if (!cancelled) {
+                setPresetWarning(
+                    `Preset "${e.payload.requested}" is no longer available — switched to "${e.payload.applied}"`,
+                );
+            }
+        }).then((u) => (cancelled ? u() : (unsub = u)));
+
+        return () => {
+            cancelled = true;
+            unsub?.();
+        };
+    }, []);
+
     async function loadInstance() {
         try {
             const all = await listInstances();
@@ -171,6 +195,9 @@ export default function App() {
                 setInstance(found);
                 setPhase("ready");
                 checkUpdate(found);
+                listPresets(found.id)
+                    .then(setPresets)
+                    .catch(() => {});
             } else {
                 // First run — fetch latest release then install
                 setPhase("installing");
@@ -224,9 +251,33 @@ export default function App() {
             setInstance(installed);
             setPhase("ready");
             setUpdateAvailable(false);
+            listPresets(installed.id)
+                .then(setPresets)
+                .catch(() => {});
         } catch (e) {
             setErrorMsg(extractError(e));
             setPhase("error");
+        }
+    }
+
+    async function handleSwitchPreset(name: string) {
+        if (!instance || switchingPreset) return;
+        setSwitchingPreset(true);
+        try {
+            const updated = await switchPreset(instance.id, name);
+            setInstance(updated);
+        } catch (e) {
+            setPresetWarning(extractError(e));
+        } finally {
+            setSwitchingPreset(false);
+        }
+    }
+
+    async function handleOpenFolder() {
+        try {
+            await openDataFolder();
+        } catch {
+            // silently ignore — file manager may not be available
         }
     }
 
@@ -310,6 +361,13 @@ export default function App() {
             <div className={styles.topBar}>
                 <div className={styles.topBarDrag} data-tauri-drag-region />
                 <button
+                    className={styles.folderBtn}
+                    onClick={handleOpenFolder}
+                    title="Open data folder"
+                >
+                    <FolderIcon />
+                </button>
+                <button
                     className={styles.settingsBtn}
                     onClick={() => setShowSettings((v) => !v)}
                     title={showSettings ? "Home" : "Settings"}
@@ -384,6 +442,44 @@ export default function App() {
                         <div className={styles.packName}>Starlight</div>
                         {versionParts.length > 0 && (
                             <div className={styles.packVersion}>{versionParts.join(" · ")}</div>
+                        )}
+
+                        {/* Preset switcher — only shown when multiple presets exist */}
+                        {presets.length > 1 && (
+                            <div className={styles.presetRow}>
+                                {presets.map((preset) => (
+                                    <button
+                                        key={preset}
+                                        className={`${styles.presetBtn} ${
+                                            instance?.active_preset === preset
+                                                ? styles.presetBtnActive
+                                                : ""
+                                        }`}
+                                        onClick={() => handleSwitchPreset(preset)}
+                                        disabled={
+                                            busy ||
+                                            switchingPreset ||
+                                            instance?.active_preset === preset
+                                        }
+                                        title={preset}
+                                    >
+                                        {preset}
+                                    </button>
+                                ))}
+                            </div>
+                        )}
+
+                        {/* Preset fallback warning */}
+                        {presetWarning && (
+                            <div className={styles.presetWarning}>
+                                <span className={styles.presetWarningText}>{presetWarning}</span>
+                                <button
+                                    className={styles.dismissBtn}
+                                    onClick={() => setPresetWarning(null)}
+                                >
+                                    ×
+                                </button>
+                            </div>
                         )}
 
                         {/* Play button */}
@@ -572,6 +668,23 @@ function HomeIcon() {
         >
             <path d="M3 9.5L12 3l9 6.5V20a1 1 0 0 1-1 1H4a1 1 0 0 1-1-1V9.5z" />
             <path d="M9 21V12h6v9" />
+        </svg>
+    );
+}
+
+function FolderIcon() {
+    return (
+        <svg
+            width="14"
+            height="14"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth="2"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+        >
+            <path d="M22 19a2 2 0 0 1-2 2H4a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h5l2 3h9a2 2 0 0 1 2 2z" />
         </svg>
     );
 }

--- a/src/api/install.ts
+++ b/src/api/install.ts
@@ -7,9 +7,9 @@ export async function installModpack(projectId: string, versionId: string): Prom
 
 export async function installStarlight(release: GithubRelease): Promise<Instance> {
     return invoke("install_starlight", {
-        mrpackUrl: release.mrpack_url,
-        mrpackName: release.mrpack_name,
-        mrpackSize: release.mrpack_size,
+        assetUrl: release.asset_url,
+        assetName: release.asset_name,
+        assetSize: release.asset_size,
         versionTag: release.tag,
     });
 }

--- a/src/api/presets.ts
+++ b/src/api/presets.ts
@@ -1,0 +1,14 @@
+import { invoke } from "@tauri-apps/api/core";
+import type { Instance } from "@/types";
+
+export async function listPresets(instanceId: string): Promise<string[]> {
+    return invoke("list_presets", { instanceId });
+}
+
+export async function switchPreset(instanceId: string, presetName: string): Promise<Instance> {
+    return invoke("switch_preset", { instanceId, presetName });
+}
+
+export async function openDataFolder(): Promise<void> {
+    return invoke("open_data_folder");
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -9,6 +9,7 @@ export interface Instance {
     last_played: string | null;
     jvm_args: string[];
     memory_mb: number;
+    active_preset: string | null;
 }
 
 export interface ModpackInfo {
@@ -62,7 +63,7 @@ export interface GameExitEvent {
 // GitHub release info
 export interface GithubRelease {
     tag: string;
-    mrpack_url: string;
-    mrpack_name: string;
-    mrpack_size: number;
+    asset_url: string;
+    asset_name: string;
+    asset_size: number;
 }


### PR DESCRIPTION
- Download *-client-presets.zip from GitHub releases; extract each .mrpack into instances/{id}/presets/ (falls back to plain -client.mrpack for older releases)
- Add active_preset field to Instance; persists across updates — if the previous preset no longer ships in a new release, fall back to the first available preset and emit a preset-fallback event shown in the UI
- Rename instance game directory from .minecraft to game; auto-migrate existing instances on startup
- Preserve saves/ and servers.dat on both pack update and preset switch
- Add list_presets / switch_preset Tauri commands
- Add open_data_folder command (tauri-plugin-opener)
- UI: folder button left of settings, preset switcher row, fallback warning